### PR TITLE
Added SQS Publisher for Notifications

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,11 +18,14 @@ jobs:
     - name: Install protoc-gen
       run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
-    - name: Build PB
-      run: make protos
-
-    - name: Start local Redis
-      run: docker run -d -p 6379:6379 redis:6.2-alpine
+    - name: Build
+      run: export GOPATH=/home/runner/go && mkdir -p $GOPATH/bin && make all
+      
+    - name: Run Containers
+      run: docker-compose up -d
+      
+    - name: Copy Bogus AWS creds
+      run: cp data/credentials ${HOME}/.aws/
       
     - name: Test
-      run: go test ./api ./server ./storage
+      run: go test ./api ./pubsub ./server ./storage

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -19,13 +19,13 @@ jobs:
       run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
     - name: Build
-      run: export GOPATH=/home/runner/go && mkdir -p $GOPATH/bin && make all
+      run: export GOPATH=/home/runner/go && mkdir -p ${GOPATH}/bin && make all
       
     - name: Run Containers
       run: docker-compose up -d
       
     - name: Copy Bogus AWS creds
-      run: cp data/credentials ${HOME}/.aws/
+      run: mkdir -p ${HOME}/.aws && cp data/credentials ${HOME}/.aws/
       
     - name: Test
       run: go test ./api ./pubsub ./server ./storage

--- a/Makefile
+++ b/Makefile
@@ -2,36 +2,39 @@
 # (Reluctantly) Created by M. Massenzio, 2022-03-14
 
 out = ${GOPATH}/bin/sm-server
+pkgs = ./api ./pubsub ./server ./storage
 
-api/statemachine.pb.go:
+api/statemachine.pb.go: protos/statemachine.proto
 	protoc --proto_path=protos/ \
                --go_out=api/ \
                --go_opt=paths=source_relative \
                protos/*.proto
 
-protos: api/statemachine.pb.go
-
-all: protos cmd/server.go
+all: api/statemachine.pb.go cmd/server.go
 	go build -o $(out) cmd/server.go
 	@chmod +x $(out)
 
-# TODO: Add dependencies for test files.
 test: all
-	@docker-compose up -d redis
-	ginkgo -p ./api ./server ./storage
+	@docker-compose up -d
+	ginkgo -p $(pkgs)
 
 # Runs test coverage and displays the results in browser
 cov: all
-	@go test -coverprofile=/tmp/cov.out ./api ./server ./storage
+	@docker-compose up -d
+	@go test -coverprofile=/tmp/cov.out $(pkgs)
 	@go tool cover -html=/tmp/cov.out
 
 clean:
-	@rm -f api/*.pb.go
-	@rm -f $(out)
+	@rm -f api/*.pb.go $(out)
 
-# This is just an example to show how to run the server.
-# Runs the server on http://localhost:8089 in debug mode.
-run: all test
-	@docker-compose up -d redis
-	$(out) --port 8089 --local --debug \
-		--redis localhost:6379 --sqs test-sm
+# This is just an example to show how to locally run the server.
+# Runs the server on http://localhost:8089 in debug mode, using entirely
+# local services (Redis and SQS).
+run: all
+	@docker-compose up -d
+	@for queue in events notifications; do \
+		aws --no-cli-pager --endpoint-url=http://localhost:4566 --region us-west-2 \
+ 			sqs create-queue --queue-name $$queue; done >/dev/null
+	$(out) -port 8089 -local -debug \
+		-redis localhost:6379 -sqs http://localhost:4566 \
+		-events events -errors notifications

--- a/api/fsm.go
+++ b/api/fsm.go
@@ -34,6 +34,7 @@ var MissingStatesConfigurationError = fmt.Errorf(
     "configuration must always specify at least one state")
 var MismatchStartingStateConfigurationError = fmt.Errorf(
     "the StartingState must be one of the possible FSM states")
+var EmptyStartingStateConfigurationError = fmt.Errorf("the StartingState must be non-empty")
 
 var NotImplementedError = fmt.Errorf("not implemented")
 
@@ -158,7 +159,10 @@ func (x *Configuration) CheckValid() error {
     if len(x.States) == 0 {
         return MissingStatesConfigurationError
     }
-    if x.StartingState == "" || !x.HasState(x.StartingState) {
+    if x.StartingState == "" {
+        return EmptyStartingStateConfigurationError
+    }
+    if !x.HasState(x.StartingState) {
         return MismatchStartingStateConfigurationError
     }
     // TODO: we should actually build the full graph and check it's fully connected.

--- a/api/fsm.go
+++ b/api/fsm.go
@@ -32,7 +32,7 @@ var MissingNameConfigurationError = fmt.Errorf("configuration must always specif
     "and optionally a version)")
 var MissingStatesConfigurationError = fmt.Errorf(
     "configuration must always specify at least one state")
-var MismatchStartingstateConfigurationError = fmt.Errorf(
+var MismatchStartingStateConfigurationError = fmt.Errorf(
     "the StartingState must be one of the possible FSM states")
 
 var NotImplementedError = fmt.Errorf("not implemented")
@@ -136,10 +136,10 @@ func (x *Configuration) HasState(state string) bool {
     return false
 }
 
-// CheckValid checks that the Configuration is valid and that the current FSM's `state` is one of
+// CheckValid checks that the Configuration is valid and that the current FSM `state` is one of
 // the allowed states in the Configuration.
 //
-// We also check that the reported FSM's ConfigId, matches the Configuration's name, version.
+// We also check that the reported FSM ConfigId, matches the Configuration's name, version.
 func (x *ConfiguredStateMachine) CheckValid() bool {
     return x.Config.CheckValid() == nil && x.Config.HasState(x.FSM.State) &&
         x.FSM.ConfigId == x.Config.GetVersionId()
@@ -159,7 +159,7 @@ func (x *Configuration) CheckValid() error {
         return MissingStatesConfigurationError
     }
     if x.StartingState == "" || !x.HasState(x.StartingState) {
-        return MismatchStartingstateConfigurationError
+        return MismatchStartingStateConfigurationError
     }
     // TODO: we should actually build the full graph and check it's fully connected.
     for _, s := range x.States {

--- a/api/statemachine_test.go
+++ b/api/statemachine_test.go
@@ -19,53 +19,53 @@
 package api_test
 
 import (
-	"github.com/golang/protobuf/jsonpb"
-	log "github.com/massenz/go-statemachine/logging"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"io/ioutil"
+    "github.com/golang/protobuf/jsonpb"
+    log "github.com/massenz/go-statemachine/logging"
+    . "github.com/onsi/ginkgo"
+    . "github.com/onsi/gomega"
+    "io/ioutil"
 
-	. "github.com/massenz/go-statemachine/api"
+    . "github.com/massenz/go-statemachine/api"
 )
 
 var _ = Describe("FSM Protocol Buffers", func() {
-	BeforeEach(func() { Logger = log.NullLog })
-	Context("if well defined", func() {
-		It("can be initialized", func() {
-			var spaceship = Configuration{
-				StartingState: "earth",
-				States:        []string{"earth", "orbit", "mars"},
-				Transitions: []*Transition{
-					{From: "earth", To: "orbit", Event: "launch"},
-					{From: "orbit", To: "mars", Event: "land"},
-				},
-			}
-			Expect(spaceship.StartingState).To(Equal("earth"))
-			Expect(len(spaceship.States)).To(Equal(3))
-			Expect(spaceship.Transitions).ToNot(BeEmpty())
-			Expect(spaceship.Transitions[0]).ToNot(BeNil())
-		})
-		It("can be created and used", func() {
-			fsm := &FiniteStateMachine{}
-			fsm.State = "mars"
-			Expect(fsm).ShouldNot(BeNil())
-			Expect(fsm.State).Should(Equal("mars"))
-			Expect(fsm.History).Should(BeEmpty())
-		})
-	})
+    BeforeEach(func() { Logger = log.NullLog })
+    Context("if well defined", func() {
+        It("can be initialized", func() {
+            var spaceship = Configuration{
+                StartingState: "earth",
+                States:        []string{"earth", "orbit", "mars"},
+                Transitions: []*Transition{
+                    {From: "earth", To: "orbit", Event: "launch"},
+                    {From: "orbit", To: "mars", Event: "land"},
+                },
+            }
+            Expect(spaceship.StartingState).To(Equal("earth"))
+            Expect(len(spaceship.States)).To(Equal(3))
+            Expect(spaceship.Transitions).ToNot(BeEmpty())
+            Expect(spaceship.Transitions[0]).ToNot(BeNil())
+        })
+        It("can be created and used", func() {
+            fsm := &FiniteStateMachine{}
+            fsm.State = "mars"
+            Expect(fsm).ShouldNot(BeNil())
+            Expect(fsm.State).Should(Equal("mars"))
+            Expect(fsm.History).Should(BeEmpty())
+        })
+    })
 
-	Context("when defined via JSON", func() {
-		var (
-			t                                 = Transition{}
-			evt                               = Event{}
-			gccConfig                         = Configuration{}
-			transition, simpleEvent, compiler string
-		)
+    Context("when defined via JSON", func() {
+        var (
+            t                                 = Transition{}
+            evt                               = Event{}
+            gccConfig                         = Configuration{}
+            transition, simpleEvent, compiler string
+        )
 
-		BeforeEach(func() {
-			transition = `{"from": "source", "to": "binary", "event": "build"}`
-			simpleEvent = `{"transition": {"event": "build"}}`
-			compiler = `{
+        BeforeEach(func() {
+            transition = `{"from": "source", "to": "binary", "event": "build"}`
+            simpleEvent = `{"transition": {"event": "build"}}`
+            compiler = `{
 			"name": "compiler",
 			"version": "v1",
 			"states": ["source", "tested", "binary"],
@@ -75,144 +75,144 @@ var _ = Describe("FSM Protocol Buffers", func() {
 			],
 			"starting_state": "source"
 		}`
-		})
+        })
 
-		It("can be parsed without errors", func() {
+        It("can be parsed without errors", func() {
 
-			Expect(jsonpb.UnmarshalString(transition, &t)).ShouldNot(HaveOccurred())
-			Expect(t.From).To(Equal("source"))
-			Expect(t.To).To(Equal("binary"))
-			Expect(t.Event).To(Equal("build"))
-		})
-		It("events only need the name of the event to pars", func() {
-			Expect(jsonpb.UnmarshalString(simpleEvent, &evt)).ShouldNot(HaveOccurred())
-			Expect(evt.Transition.Event).To(Equal("build"))
+            Expect(jsonpb.UnmarshalString(transition, &t)).ShouldNot(HaveOccurred())
+            Expect(t.From).To(Equal("source"))
+            Expect(t.To).To(Equal("binary"))
+            Expect(t.Event).To(Equal("build"))
+        })
+        It("events only need the name of the event to pars", func() {
+            Expect(jsonpb.UnmarshalString(simpleEvent, &evt)).ShouldNot(HaveOccurred())
+            Expect(evt.Transition.Event).To(Equal("build"))
 
-		})
-		It("can define complex configurations", func() {
-			Expect(jsonpb.UnmarshalString(compiler, &gccConfig)).ShouldNot(HaveOccurred())
-			Expect(len(gccConfig.States)).To(Equal(3))
-			Expect(len(gccConfig.Transitions)).To(Equal(2))
-			Expect(gccConfig.Version).To(Equal("v1"))
-		})
-		It("can be used to create FSMs", func() {
-			Expect(jsonpb.UnmarshalString(compiler, &gccConfig)).ShouldNot(HaveOccurred())
-			fsm, err := NewStateMachine(&gccConfig)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(fsm.FSM.State).To(Equal("source"))
-			Expect(fsm.FSM.ConfigId).To(Equal("compiler:v1"))
+        })
+        It("can define complex configurations", func() {
+            Expect(jsonpb.UnmarshalString(compiler, &gccConfig)).ShouldNot(HaveOccurred())
+            Expect(len(gccConfig.States)).To(Equal(3))
+            Expect(len(gccConfig.Transitions)).To(Equal(2))
+            Expect(gccConfig.Version).To(Equal("v1"))
+        })
+        It("can be used to create FSMs", func() {
+            Expect(jsonpb.UnmarshalString(compiler, &gccConfig)).ShouldNot(HaveOccurred())
+            fsm, err := NewStateMachine(&gccConfig)
+            Expect(err).ShouldNot(HaveOccurred())
+            Expect(fsm.FSM.State).To(Equal("source"))
+            Expect(fsm.FSM.ConfigId).To(Equal("compiler:v1"))
 
-		})
-	})
+        })
+    })
 
-	Describe("Finite State Machines", func() {
-		Context("with an unnamed configuration", func() {
-			var spaceship Configuration
+    Describe("Finite State Machines", func() {
+        Context("with an unnamed configuration", func() {
+            var spaceship Configuration
 
-			BeforeEach(func() {
-				spaceship = Configuration{
-					StartingState: "earth",
-					States:        []string{"earth", "orbit", "mars"},
-					Transitions: []*Transition{
-						{From: "earth", To: "orbit", Event: "launch"},
-						{From: "orbit", To: "mars", Event: "land"},
-					},
-				}
-			})
+            BeforeEach(func() {
+                spaceship = Configuration{
+                    StartingState: "earth",
+                    States:        []string{"earth", "orbit", "mars"},
+                    Transitions: []*Transition{
+                        {From: "earth", To: "orbit", Event: "launch"},
+                        {From: "orbit", To: "mars", Event: "land"},
+                    },
+                }
+            })
 
-			It("without name will fail", func() {
-				_, err := NewStateMachine(&spaceship)
-				Expect(err).Should(HaveOccurred())
-			})
-			It("will get a default version, if missing", func() {
-				spaceship.Name = "mars_orbiter"
-				s, err := NewStateMachine(&spaceship)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(s.FSM.ConfigId).To(Equal("mars_orbiter:v1"))
-			})
-			It("will carry the configuration embedded", func() {
-				spaceship.Name = "mars_orbiter"
-				spaceship.Version = "v3"
-				s, err := NewStateMachine(&spaceship)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(s).ToNot(BeNil())
-				Expect(s.Config).ToNot(BeNil())
-				Expect(s.Config.String()).To(Equal(spaceship.String()))
-				Expect(s.FSM.ConfigId).To(Equal(spaceship.GetVersionId()))
-			})
-		})
+            It("without name will fail", func() {
+                _, err := NewStateMachine(&spaceship)
+                Expect(err).Should(HaveOccurred())
+            })
+            It("will get a default version, if missing", func() {
+                spaceship.Name = "mars_orbiter"
+                s, err := NewStateMachine(&spaceship)
+                Expect(err).ShouldNot(HaveOccurred())
+                Expect(s.FSM.ConfigId).To(Equal("mars_orbiter:v1"))
+            })
+            It("will carry the configuration embedded", func() {
+                spaceship.Name = "mars_orbiter"
+                spaceship.Version = "v3"
+                s, err := NewStateMachine(&spaceship)
+                Expect(err).ToNot(HaveOccurred())
+                Expect(s).ToNot(BeNil())
+                Expect(s.Config).ToNot(BeNil())
+                Expect(s.Config.String()).To(Equal(spaceship.String()))
+                Expect(s.FSM.ConfigId).To(Equal(spaceship.GetVersionId()))
+            })
+        })
 
-		Context("with a valid configuration", func() {
-			defer GinkgoRecover()
-			var spaceship Configuration
+        Context("with a valid configuration", func() {
+            defer GinkgoRecover()
+            var spaceship Configuration
 
-			BeforeEach(func() {
-				spaceship = Configuration{
-					Name:          "mars_rover",
-					Version:       "v2.0",
-					StartingState: "earth",
-					States:        []string{"earth", "orbit", "mars"},
-					Transitions: []*Transition{
-						{From: "earth", To: "orbit", Event: "launch"},
-						{From: "orbit", To: "mars", Event: "land"},
-					},
-				}
-			})
-			It("can transition across states ", func() {
-				lander, err := NewStateMachine(&spaceship)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(lander.FSM.State).To(Equal("earth"))
-				Expect(lander.SendEvent("launch")).ShouldNot(HaveOccurred())
-				Expect(lander.FSM.State).To(Equal("orbit"))
-				Expect(lander.SendEvent("land")).ShouldNot(HaveOccurred())
-				Expect(lander.FSM.State).To(Equal("mars"))
-			})
-			It("should fail for an unsupported transition", func() {
-				lander, _ := NewStateMachine(&spaceship)
-				Expect(lander.SendEvent("navigate")).Should(HaveOccurred())
-			})
-			It("can be reset", func() {
-				lander, _ := NewStateMachine(&spaceship)
-				Expect(lander.SendEvent("launch")).ShouldNot(HaveOccurred())
-				Expect(lander.SendEvent("land")).ShouldNot(HaveOccurred())
-				Expect(lander.FSM.State).To(Equal("mars"))
+            BeforeEach(func() {
+                spaceship = Configuration{
+                    Name:          "mars_rover",
+                    Version:       "v2.0",
+                    StartingState: "earth",
+                    States:        []string{"earth", "orbit", "mars"},
+                    Transitions: []*Transition{
+                        {From: "earth", To: "orbit", Event: "launch"},
+                        {From: "orbit", To: "mars", Event: "land"},
+                    },
+                }
+            })
+            It("can transition across states ", func() {
+                lander, err := NewStateMachine(&spaceship)
+                Expect(err).ToNot(HaveOccurred())
+                Expect(lander.FSM.State).To(Equal("earth"))
+                Expect(lander.SendEvent("launch")).ShouldNot(HaveOccurred())
+                Expect(lander.FSM.State).To(Equal("orbit"))
+                Expect(lander.SendEvent("land")).ShouldNot(HaveOccurred())
+                Expect(lander.FSM.State).To(Equal("mars"))
+            })
+            It("should fail for an unsupported transition", func() {
+                lander, _ := NewStateMachine(&spaceship)
+                Expect(lander.SendEvent("navigate")).Should(HaveOccurred())
+            })
+            It("can be reset", func() {
+                lander, _ := NewStateMachine(&spaceship)
+                Expect(lander.SendEvent("launch")).ShouldNot(HaveOccurred())
+                Expect(lander.SendEvent("land")).ShouldNot(HaveOccurred())
+                Expect(lander.FSM.State).To(Equal("mars"))
 
-				// Never mind, Elon, let's go home...
-				lander.Reset()
-				Expect(lander.FSM.State).To(Equal("earth"))
-				Expect(lander.FSM.History).To(BeNil())
-			})
-		})
+                // Never mind, Elon, let's go home...
+                lander.Reset()
+                Expect(lander.FSM.State).To(Equal("earth"))
+                Expect(lander.FSM.History).To(BeNil())
+            })
+        })
 
-		Context("can be configured via complex JSON", func() {
-			defer GinkgoRecover()
-			var (
-				orders     Configuration
-				configJson []byte
-			)
-			BeforeEach(func() {
-				var err error
-				configJson, err = ioutil.ReadFile("../data/orders.json")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(jsonpb.UnmarshalString(string(configJson), &orders)).ToNot(HaveOccurred())
-			})
-			It("JSON can be unmarshaled", func() {
-				Expect(orders.Name).To(Equal("test.orders"))
-				Expect(orders.Version).To(Equal("v1"))
+        Context("can be configured via complex JSON", func() {
+            defer GinkgoRecover()
+            var (
+                orders     Configuration
+                configJson []byte
+            )
+            BeforeEach(func() {
+                var err error
+                configJson, err = ioutil.ReadFile("../data/orders.json")
+                Expect(err).ToNot(HaveOccurred())
+                Expect(jsonpb.UnmarshalString(string(configJson), &orders)).ToNot(HaveOccurred())
+            })
+            It("JSON can be unmarshalled", func() {
+                Expect(orders.Name).To(Equal("test.orders"))
+                Expect(orders.Version).To(Equal("v1"))
 
-			})
-			It("can be created and events received", func() {
-				fsm, err := NewStateMachine(&orders)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(fsm.FSM).ToNot(BeNil())
-				Expect(fsm.FSM.State).To(Equal("start"))
+            })
+            It("can be created and events received", func() {
+                fsm, err := NewStateMachine(&orders)
+                Expect(err).ToNot(HaveOccurred())
+                Expect(fsm.FSM).ToNot(BeNil())
+                Expect(fsm.FSM.State).To(Equal("start"))
 
-				Expect(fsm.SendEvent("accepted")).ToNot(HaveOccurred())
-				Expect(fsm.SendEvent("shipped")).ToNot(HaveOccurred())
+                Expect(fsm.SendEvent("accepted")).ToNot(HaveOccurred())
+                Expect(fsm.SendEvent("shipped")).ToNot(HaveOccurred())
 
-				Expect(fsm.FSM.State).To(Equal("shipping"))
-				Expect(len(fsm.FSM.History)).To(Equal(2))
-			})
-		})
-	})
+                Expect(fsm.FSM.State).To(Equal("shipping"))
+                Expect(len(fsm.FSM.History)).To(Equal(2))
+            })
+        })
+    })
 })

--- a/data/credentials
+++ b/data/credentials
@@ -1,0 +1,7 @@
+# Bogus AWS Default credentials to make the tests run in LocalStack
+#
+# Created 2022-05-11
+
+[default]
+aws_access_key_id = foobar
+aws_secret_access_key = zekret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,65 +1,39 @@
-# Copyright CopilotIQ Inc. (c) 2022. All rights reserved.
+# Copyright AlertAvert Inc. (c) 2022. All rights reserved.
 #
-# Docker Compose for Development of Patient API.
+# Docker Compose for Statemachine local development ONLY.
 
 version: '3.2'
-
-
 services:
-
   redis:
     container_name: "redis"
     image: "redis:6.2-alpine"
     hostname: redis
-    # TODO: add support for persistent data
-    #  command: "redis-server --save 60 1 --loglevel warning"
-    #  volumes:
-    #    - redis_data:/data
-
+    command: "redis-server --save 60 1 --loglevel warning"
+    volumes:
+      - "${TMPDIR:-/tmp}/redis:/data"
     ports:
       - "6379:6379"
     networks:
       - backend
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.0.1
-    hostname: zookeeper
-    container_name: zookeeper
+  localstack:
+    container_name: "aws-sqs"
+    image: "localstack/localstack:latest"
+    hostname: aws-sqs
+    environment:
+      - AWS_REGION=us-west-2
+      - EDGE_PORT=4566
+      - SERVICES=sqs
     ports:
-      - "32181:32181"
+      - '4566:4566'
+    volumes:
+      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
     networks:
       - backend
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 32181
-      ZOOKEEPER_TICK_TIME: 2000
-
-  kafka:
-    image: confluentinc/cp-kafka:7.0.1
-    hostname: kafka0
-    container_name: kafka
-    depends_on:
-      - zookeeper
-    ports:
-      - "9092:9092"
-    networks:
-      - backend
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:32181'
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_LISTENERS: DOCKER://0.0.0.0:29092,LOCAL://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: DOCKER://kafka0:29092,LOCAL://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: DOCKER:PLAINTEXT,LOCAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: DOCKER
-
-
-### INFRASTRUCTURE
-
-volumes:
-  redis_data:
 
 # To connect to the servers in this stack, from a container run
-# via Docker, use `--network statemachine`.
+# via Docker, use `--network statemachine_backend`.
 # The hosts listed above will then be reachable at the given names,
 # on whatever ports are exposed.
 networks:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/massenz/go-statemachine
 
-// TODO @MM: move to 1.18 and use generics
+// TODO: Move to 1.18 and use generics
 go 1.16
 
 require (

--- a/logging/log.go
+++ b/logging/log.go
@@ -107,7 +107,7 @@ func NewLogToWriter(writer io.Writer, name string) *Log {
 }
 
 // RootLog is the default log
-var RootLog = NewLog("")
+var RootLog = NewLog("ROOT")
 
 var none, _ = os.Open(os.DevNull)
 

--- a/pubsub/listener.go
+++ b/pubsub/listener.go
@@ -19,32 +19,11 @@
 package pubsub
 
 import (
-    "bytes"
     "fmt"
     "github.com/massenz/go-statemachine/api"
     "github.com/massenz/go-statemachine/logging"
-    "github.com/massenz/go-statemachine/storage"
     "google.golang.org/protobuf/types/known/timestamppb"
 )
-
-// An EventsListener will process EventMessage in a separate goroutine.
-// The messages are posted on an `events` channel, and if any error is encountered,
-// error messages are posted on a `notifications` channel for further processing upstream.
-type EventsListener struct {
-    logger        *logging.Log
-    events        <-chan EventMessage
-    notifications chan<- EventErrorMessage
-    store         storage.StoreManager
-}
-
-// ListenerOptions are used to configure an EventsListener at creation and are used
-// to decouple the internals of the listener from its exposed configuration.
-type ListenerOptions struct {
-    EventsChannel        <-chan EventMessage
-    NotificationsChannel chan<- EventErrorMessage
-    StatemachinesStore   storage.StoreManager
-    ListenersPoolSize    int8
-}
 
 func NewEventsListener(options *ListenerOptions) *EventsListener {
     return &EventsListener{
@@ -60,25 +39,11 @@ func (l *EventsListener) SetLogLevel(level logging.LogLevel) {
     l.logger.Level = level
 }
 
-func (l *EventsListener) PostErrorNotification(msg EventMessage, err error, detail string) {
-    var msgBuf bytes.Buffer
-    fmt.Fprintf(&msgBuf, "error processing event %s", msg)
-    if err != nil {
-        fmt.Fprintf(&msgBuf, ": %v", err)
-    }
-    if detail != "" {
-        fmt.Fprintf(&msgBuf, " (%s)", detail)
-    }
-    l.logger.Error(msgBuf.String())
-
-    var errorMsg = EventErrorMessage{
-        Error:       *NewEventProcessingError(err),
-        ErrorDetail: detail,
-        Message:     &msg,
-    }
+func (l *EventsListener) PostErrorNotification(error *EventErrorMessage) {
+    l.logger.Error(error.String())
     if l.notifications != nil {
-        l.logger.Debug("Posting notification of error")
-        l.notifications <- errorMsg
+        l.logger.Debug("Posting notification of error: %v", *error)
+        l.notifications <- *error
     }
 }
 
@@ -87,20 +52,20 @@ func (l *EventsListener) ListenForMessages() {
     for event := range l.events {
         l.logger.Debug("Received event %s", event)
         if event.Destination == "" {
-            l.PostErrorNotification(event, fmt.Errorf("no destination for event"), "")
+            l.PostErrorNotification(ErrorMessage(fmt.Errorf("no destination for event"), &event))
             continue
         }
         fsm, ok := l.store.GetStateMachine(event.Destination)
         if !ok {
-            l.PostErrorNotification(event, fmt.Errorf("statemachine [%s] could not be found",
-                event.Destination), "")
+            l.PostErrorNotification(ErrorMessage(fmt.Errorf("statemachine [%s] could not be found",
+                event.Destination), &event))
             continue
         }
         // TODO: cache the configuration locally: they are immutable anyway.
         cfg, ok := l.store.GetConfig(fsm.ConfigId)
         if !ok {
-            l.PostErrorNotification(event, fmt.Errorf("configuration [%s] could not be found",
-                fsm.ConfigId), "")
+            l.PostErrorNotification(ErrorMessage(fmt.Errorf("configuration [%s] could not be found",
+                fsm.ConfigId), &event))
             continue
         }
 
@@ -110,13 +75,13 @@ func (l *EventsListener) ListenForMessages() {
         }
         pbEvent := NewPBEvent(event)
         if err := cfgFsm.SendEvent(pbEvent.Transition.Event); err != nil {
-            l.PostErrorNotification(event, err, fmt.Sprintf(
-                "FSM [%s] cannot process event `%s`", event.Destination, event.EventName))
+            l.PostErrorNotification(ErrorMessageWithDetail(err, &event, fmt.Sprintf(
+                "FSM [%s] cannot process event `%s`", event.Destination, event.EventName)))
             continue
         }
         err := l.store.PutStateMachine(event.Destination, fsm)
         if err != nil {
-            l.PostErrorNotification(event, err, "")
+            l.PostErrorNotification(ErrorMessage(err, &event))
             continue
         }
         l.logger.Debug("Event %s transitioned FSM [%s] to state `%s`",
@@ -126,8 +91,9 @@ func (l *EventsListener) ListenForMessages() {
 
 func NewPBEvent(message EventMessage) *api.Event {
     return &api.Event{
-        EventId:   message.EventId,
-        Timestamp: timestamppb.New(message.EventTimestamp),
+        EventId:    message.EventId,
+        Originator: message.Sender,
+        Timestamp:  timestamppb.New(message.EventTimestamp),
         Transition: &api.Transition{
             Event: message.EventName,
         },

--- a/pubsub/listener_test.go
+++ b/pubsub/listener_test.go
@@ -1,0 +1,203 @@
+package pubsub_test
+
+import (
+    "fmt"
+    . "github.com/JiaYongfei/respect/gomega"
+    "github.com/massenz/go-statemachine/api"
+    log "github.com/massenz/go-statemachine/logging"
+    "github.com/massenz/go-statemachine/storage"
+    . "github.com/onsi/ginkgo"
+    . "github.com/onsi/gomega"
+    "time"
+
+    "github.com/massenz/go-statemachine/pubsub"
+)
+
+var _ = Describe("A Listener", func() {
+    Context("from an EventMessage", func() {
+        It("can create a PB Event", func() {
+            msg := pubsub.EventMessage{
+                Sender:      "test-sender",
+                Destination: "test-destination",
+                EventId:     "test-abed",
+                EventName:   "an-event",
+                // 2022-05-09T22:52:39+0000
+                EventTimestamp: time.Unix(1652161959, 0),
+            }
+            evt := pubsub.NewPBEvent(msg)
+            Expect(evt).ToNot(BeNil())
+            Expect(evt.EventId).To(Equal(msg.EventId))
+            Expect(evt.Transition).ToNot(BeNil())
+            Expect(evt.Transition.Event).To(Equal(msg.EventName))
+            Expect(evt.Timestamp.AsTime().Unix()).To(Equal(msg.EventTimestamp.Unix()))
+            Expect(evt.Originator).To(Equal(msg.Sender))
+        })
+    })
+
+    Context("when store-backed", func() {
+        var (
+            testListener    *pubsub.EventsListener
+            eventsCh        chan pubsub.EventMessage
+            notificationsCh chan pubsub.EventErrorMessage
+            store           storage.StoreManager
+        )
+        BeforeEach(func() {
+            eventsCh = make(chan pubsub.EventMessage)
+            notificationsCh = make(chan pubsub.EventErrorMessage)
+            store = storage.NewInMemoryStore()
+            testListener = pubsub.NewEventsListener(&pubsub.ListenerOptions{
+                EventsChannel:        eventsCh,
+                NotificationsChannel: notificationsCh,
+                StatemachinesStore:   store,
+                ListenersPoolSize:    0,
+            })
+            // Set to DEBUG when diagnosing test failures
+            testListener.SetLogLevel(log.NONE)
+        })
+        It("can post error notifications", func() {
+            defer close(notificationsCh)
+            msg := pubsub.EventMessage{
+                Sender:    "me",
+                EventId:   "feed-beef",
+                EventName: "test-me",
+            }
+            detail := "more details about the error"
+            notification := pubsub.ErrorMessageWithDetail(fmt.Errorf("this is a test"), &msg, detail)
+            go testListener.PostErrorNotification(notification)
+            select {
+            case n := <-notificationsCh:
+                Expect(n.Error.Error()).To(Equal("this is a test"))
+                Expect(n.Message).ToNot(BeNil())
+                Expect(*n.Message).To(Respect(msg))
+
+            case <-time.After(timeout):
+                Fail("timed out waiting for notification")
+            }
+        })
+        It("can receive events", func() {
+            done := make(chan interface{})
+
+            msg := pubsub.EventMessage{
+                Sender:      "1234",
+                EventId:     "feed-beef",
+                EventName:   "move",
+                Destination: "778899",
+            }
+            Expect(store.PutStateMachine(msg.Destination, &api.FiniteStateMachine{
+                ConfigId: "test.v1",
+                State:    "start",
+                History:  nil,
+            })).ToNot(HaveOccurred())
+            Expect(store.PutConfig("test.v1", &api.Configuration{
+                Name:          "test",
+                Version:       "v1",
+                States:        []string{"start", "end"},
+                Transitions:   []*api.Transition{{From: "start", To: "end", Event: "move"}},
+                StartingState: "",
+            }))
+
+            go func() {
+                defer close(done)
+                testListener.ListenForMessages()
+            }()
+            eventsCh <- msg
+            close(eventsCh)
+
+            select {
+            case n := <-notificationsCh:
+                Fail(fmt.Sprintf("unexpected error: %v", n.String()))
+            case <-done:
+                fsm, ok := store.GetStateMachine(msg.Destination)
+                Expect(ok).ToNot(BeFalse())
+                Expect(fsm.State).To(Equal("end"))
+            case <-time.After(timeout):
+                Fail("the listener did not exit when the events channel was closed")
+            }
+        })
+        It("sends notifications for missing configurations", func() {
+            msg := pubsub.EventMessage{
+                Sender:      "1234",
+                EventId:     "feed-beef",
+                EventName:   "move",
+                Destination: "778899",
+            }
+            Expect(store.PutStateMachine(msg.Destination, &api.FiniteStateMachine{
+                ConfigId: "test.v3",
+                State:    "start",
+                History:  nil,
+            })).ToNot(HaveOccurred())
+            go func() {
+                testListener.ListenForMessages()
+            }()
+            eventsCh <- msg
+            close(eventsCh)
+
+            select {
+            case n := <-notificationsCh:
+                Expect(n.Message).ToNot(BeNil())
+                Expect(n.Message.EventId).To(Equal(msg.EventId))
+                Expect(n.Error.Error()).To(Equal("configuration [test.v3] could not be found"))
+            case <-time.After(timeout):
+                Fail("the listener did not exit when the events channel was closed")
+            }
+        })
+        It("sends notifications for missing FSM", func() {
+            msg := pubsub.EventMessage{
+                Sender:      "1234",
+                EventId:     "feed-beef",
+                EventName:   "failed",
+                Destination: "fake",
+            }
+            go func() {
+                testListener.ListenForMessages()
+            }()
+            eventsCh <- msg
+            close(eventsCh)
+
+            select {
+            case n := <-notificationsCh:
+                Expect(n.Message).ToNot(BeNil())
+                Expect(n.Message.EventId).To(Equal(msg.EventId))
+                Expect(n.Error.Error()).To(Equal("statemachine [fake] could not be found"))
+
+            case <-time.After(timeout):
+                Fail("no error notification received")
+            }
+        })
+        It("sends notifications for missing destinations", func() {
+            msg := pubsub.EventMessage{
+                Sender:    "1234",
+                EventId:   "feed-beef",
+                EventName: "failed",
+            }
+            go func() {
+                testListener.ListenForMessages()
+            }()
+            eventsCh <- msg
+            close(eventsCh)
+
+            select {
+            case n := <-notificationsCh:
+                Expect(n.Message).ToNot(BeNil())
+                Expect(n.Message.EventId).To(Equal(msg.EventId))
+                Expect(n.Error.Error()).To(Equal("no destination for event"))
+            case <-time.After(timeout):
+                Fail("no error notification received")
+            }
+        })
+        It("should exit when the channel is closed", func() {
+            done := make(chan interface{})
+            go func() {
+                defer close(done)
+                testListener.ListenForMessages()
+            }()
+            close(eventsCh)
+            select {
+            case <-done:
+                Succeed()
+            case <-time.After(timeout):
+                Fail("the listener did not exit when the events channel was closed")
+            }
+        })
+    })
+})

--- a/pubsub/pubsub_suite_test.go
+++ b/pubsub/pubsub_suite_test.go
@@ -1,13 +1,126 @@
 package pubsub_test
 
 import (
-	"testing"
+    "fmt"
+    "github.com/massenz/go-statemachine/pubsub"
+    "os"
+    "testing"
+    "time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+    . "github.com/onsi/ginkgo"
+    . "github.com/onsi/gomega"
+
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/sqs"
+
+    "github.com/massenz/go-statemachine/logging"
 )
 
-func TestPubsub(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Pubsub Suite")
+const (
+    timeout            = 5 * time.Second
+    eventsQueue        = "test-events"
+    notificationsQueue = "test-notifications"
+)
+
+func TestPubSub(t *testing.T) {
+    RegisterFailHandler(Fail)
+    RunSpecs(t, "Pub/Sub Suite")
+}
+
+// Although these are constants, we cannot take the pointers unless we declare them vars.
+var (
+    sqsUrl        = "http://localhost:4566"
+    region        = "us-west-2"
+    testSqsClient = sqs.New(session.Must(session.NewSessionWithOptions(session.Options{
+        SharedConfigState: session.SharedConfigEnable,
+        Config: aws.Config{
+            Endpoint: &sqsUrl,
+            Region:   &region,
+        },
+    })))
+    testLog = logging.NewLog("PUBSUB")
+)
+
+var _ = BeforeSuite(func() {
+    testLog.Level = logging.NONE
+    Expect(os.Setenv("AWS_REGION", region)).ToNot(HaveOccurred())
+    for _, topic := range []string{eventsQueue, notificationsQueue} {
+        topic = fmt.Sprintf("%s-%d", topic, GinkgoParallelProcess())
+
+        _, err := testSqsClient.GetQueueUrl(&sqs.GetQueueUrlInput{
+            QueueName: &topic,
+        })
+        if err != nil {
+            // the queue does not exist and ought to be created
+            testLog.Info("Creating SQS Queue %s", topic)
+            _, err = testSqsClient.CreateQueue(&sqs.CreateQueueInput{
+                QueueName: &topic,
+            })
+            Expect(err).NotTo(HaveOccurred())
+        }
+    }
+})
+
+var _ = AfterSuite(func() {
+    for _, topic := range []string{eventsQueue, notificationsQueue} {
+        topic = getQueueName(topic)
+
+        out, err := testSqsClient.GetQueueUrl(&sqs.GetQueueUrlInput{
+            QueueName: &topic,
+        })
+        Expect(err).NotTo(HaveOccurred())
+        if out != nil {
+            testLog.Info("Deleting SQS Queue %s", topic)
+            _, err = testSqsClient.DeleteQueue(&sqs.DeleteQueueInput{QueueUrl: out.QueueUrl})
+            Expect(err).NotTo(HaveOccurred())
+        }
+    }
+})
+
+// getQueueName provides a way to obtain a process-independent name for the SQS queue,
+// when Ginkgo tests are run in parallel (-p)
+func getQueueName(topic string) string {
+    return fmt.Sprintf("%s-%d", topic, GinkgoParallelProcess())
+}
+
+func getSqsMessage(queue string) *sqs.Message {
+    q := pubsub.GetQueueUrl(testSqsClient, queue)
+    out, err := testSqsClient.ReceiveMessage(&sqs.ReceiveMessageInput{
+        QueueUrl: &q,
+    })
+    Expect(err).ToNot(HaveOccurred())
+    Expect(len(out.Messages)).To(Equal(1))
+    _, err = testSqsClient.DeleteMessage(&sqs.DeleteMessageInput{
+        QueueUrl:      &q,
+        ReceiptHandle: out.Messages[0].ReceiptHandle,
+    })
+    Expect(err).ToNot(HaveOccurred())
+    return out.Messages[0]
+}
+
+// postSqsMessage mirrors the decoding of the SQS Message in the Subscriber and will
+// send it over the `queue`, so that we can test the Publisher can correctly receive it.
+func postSqsMessage(queue string, msg *pubsub.EventMessage) error {
+    q := pubsub.GetQueueUrl(testSqsClient, queue)
+    testLog.Debug("Post Message -- Timestamp: %v", msg.EventTimestamp)
+    _, err := testSqsClient.SendMessage(&sqs.SendMessageInput{
+        MessageAttributes: map[string]*sqs.MessageAttributeValue{
+            "DestinationId": {
+                DataType:    aws.String("String"),
+                StringValue: aws.String(msg.Destination),
+            },
+            "EventId": {
+                DataType:    aws.String("String"),
+                StringValue: aws.String(msg.EventId),
+            },
+            "Sender": {
+                DataType:    aws.String("String"),
+                StringValue: aws.String(msg.Sender),
+            },
+        },
+        MessageBody: aws.String(msg.EventName),
+        QueueUrl:    &q,
+    })
+    return err
 }

--- a/pubsub/pubsub_test.go
+++ b/pubsub/pubsub_test.go
@@ -52,5 +52,20 @@ var _ = Describe("PubSub types", func() {
             Expect(newMsg).Should(Respect(errMsg))
         })
     })
+    Context("when serializing messages with empty fields", func() {
+        var msg pubsub.EventMessage
+        BeforeEach(func() {
+            msg = pubsub.EventMessage{
+                EventName: "an-event",
+            }
+        })
 
+        It("should convert to and from JSON without loss of meaning", func() {
+            s := msg.String()
+            Expect(s).To(Equal(`{"event_name":"an-event","timestamp":"0001-01-01T00:00:00Z"}`))
+            var newMsg pubsub.EventMessage
+            Expect(json.Unmarshal([]byte(s), &newMsg)).ToNot(HaveOccurred())
+            Expect(newMsg).Should(Respect(msg))
+        })
+    })
 })

--- a/pubsub/sqs_pub.go
+++ b/pubsub/sqs_pub.go
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 AlertAvert.com.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Marco Massenzio (marco@alertavert.com)
+ */
+
+package pubsub
+
+import (
+    "fmt"
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/sqs"
+    "github.com/massenz/go-statemachine/logging"
+    "os"
+)
+
+type SqsPublisher struct {
+    logger *logging.Log
+    client *sqs.SQS
+    errors <-chan EventErrorMessage
+}
+
+// NewSqsPublisher will create a new `Publisher` to send error notifications to
+// an SQS `dead-letter queue`.
+func NewSqsPublisher(errorsChannel <-chan EventErrorMessage, sqsUrl *string) *SqsPublisher {
+    var sess *session.Session
+    if sqsUrl == nil {
+        sess = session.Must(session.NewSessionWithOptions(session.Options{
+            SharedConfigState: session.SharedConfigEnable,
+        }))
+    } else {
+        region, found := os.LookupEnv("AWS_REGION")
+        if !found {
+            fmt.Printf("No AWS Region configured, cannot connect to SQS provider at %s\n",
+                *sqsUrl)
+            return nil
+        }
+        sess = session.Must(session.NewSessionWithOptions(session.Options{
+            SharedConfigState: session.SharedConfigEnable,
+            Config: aws.Config{
+                Endpoint: sqsUrl,
+                Region:   &region,
+            },
+        }))
+    }
+    client := sqs.New(sess)
+    return &SqsPublisher{
+        logger: logging.NewLog("SQS-Pub"),
+        client: client,
+        errors: errorsChannel,
+    }
+}
+
+// SetLogLevel allows the SqsSubscriber to implement the logging.Loggable interface
+func (s *SqsPublisher) SetLogLevel(level logging.LogLevel) {
+    if s == nil {
+        fmt.Println("WARN: attempting to set log level on nil Publisher")
+        return
+    }
+    s.logger.Level = level
+}
+
+// GetQueueUrl retrieves from AWS SQS the URL for the queue, given the topic name
+func GetQueueUrl(client *sqs.SQS, topic string) string {
+    out, err := client.GetQueueUrl(&sqs.GetQueueUrlInput{
+        QueueName: &topic,
+    })
+    if err != nil || out.QueueUrl == nil {
+        // From the Google School: fail fast and noisily from an unrecoverable error
+        logging.RootLog.Fatal(fmt.Errorf("cannot get SQS Queue URL for topic %s: %v", topic, err))
+    }
+    return *out.QueueUrl
+}
+
+// Publish sends an error message to the DLQ `topic`
+func (s *SqsPublisher) Publish(topic string) {
+    queueUrl := GetQueueUrl(s.client, topic)
+    s.logger.Info("SQS Publisher started for queue: %s", queueUrl)
+
+    for msg := range s.errors {
+        delay := int64(0)
+        s.logger.Debug("Publishing %s to %s", msg.String(), queueUrl)
+        msgResult, err := s.client.SendMessage(&sqs.SendMessageInput{
+            DelaySeconds:      &delay,
+            MessageAttributes: makeAttributes(msg),
+            MessageBody:       aws.String(msg.Message.String()),
+            QueueUrl:          &queueUrl,
+        })
+        if err != nil {
+            s.logger.Error("Cannot publish msg (%s): %v", msg.String(), err)
+            continue
+        }
+        s.logger.Debug("Error msg sent to DLQ: %s", *msgResult.MessageId)
+    }
+    s.logger.Info("SQS Publisher exiting")
+}
+
+// makeAttributes is necessary as we can't just copy the strings into the MessageAttributeValue
+// values, as empty strings will cause an error with SQS.
+// This function will only add those keys for which we have an actual value.
+func makeAttributes(msg EventErrorMessage) map[string]*sqs.MessageAttributeValue {
+    res := make(map[string]*sqs.MessageAttributeValue)
+    if msg.Error.Error() != "" {
+        res["Error"] = &sqs.MessageAttributeValue{
+            DataType:    aws.String("String"),
+            StringValue: aws.String(msg.Error.Error()),
+        }
+    }
+    if msg.Message != nil && msg.Message.EventId != "" {
+        res["EventId"] = &sqs.MessageAttributeValue{
+            DataType:    aws.String("String"),
+            StringValue: aws.String(msg.Message.EventId),
+        }
+    }
+    if msg.ErrorDetail != "" {
+        res["ErrorDetails"] = &sqs.MessageAttributeValue{
+            DataType:    aws.String("String"),
+            StringValue: aws.String(msg.ErrorDetail),
+        }
+    }
+    return res
+}

--- a/pubsub/sqs_pub_test.go
+++ b/pubsub/sqs_pub_test.go
@@ -1,0 +1,119 @@
+package pubsub_test
+
+import (
+    "encoding/json"
+    "fmt"
+    . "github.com/JiaYongfei/respect/gomega"
+    . "github.com/onsi/ginkgo"
+    . "github.com/onsi/gomega"
+    "time"
+
+    log "github.com/massenz/go-statemachine/logging"
+    "github.com/massenz/go-statemachine/pubsub"
+)
+
+var _ = Describe("SQS Publisher", func() {
+
+    Context("when correctly initialized", func() {
+        var (
+            testPublisher   *pubsub.SqsPublisher
+            notificationsCh chan pubsub.EventErrorMessage
+        )
+        BeforeEach(func() {
+            notificationsCh = make(chan pubsub.EventErrorMessage)
+            testPublisher = pubsub.NewSqsPublisher(notificationsCh, &sqsUrl)
+            Expect(testPublisher).ToNot(BeNil())
+            // Set to DEBUG when diagnosing test failures
+            testPublisher.SetLogLevel(log.NONE)
+        })
+        It("can publish error notifications", func() {
+            msg := pubsub.EventMessage{
+                Sender:         "me",
+                Destination:    "some-fsm",
+                EventId:        "feed-beef",
+                EventName:      "test-me",
+                EventTimestamp: time.Now(),
+            }
+            detail := "more details about the error"
+            notification := pubsub.ErrorMessageWithDetail(fmt.Errorf("this is a test"), &msg, detail)
+            done := make(chan interface{})
+            go func() {
+                defer close(done)
+                go testPublisher.Publish(getQueueName(notificationsQueue))
+
+            }()
+            notificationsCh <- *notification
+            res := getSqsMessage(getQueueName(notificationsQueue))
+            Expect(res).ToNot(BeNil())
+            body := *res.Body
+            var sentMsg pubsub.EventMessage
+            Expect(json.Unmarshal([]byte(body), &sentMsg)).ToNot(HaveOccurred())
+            Expect(sentMsg).To(Respect(msg))
+
+            close(notificationsCh)
+            select {
+            case <-done:
+                Succeed()
+
+            case <-time.After(timeout):
+                Fail("timed out waiting for Publisher to exit")
+            }
+        })
+
+        It("will terminate gracefully when the notifications channel is closed", func() {
+            done := make(chan interface{})
+            go func() {
+                defer close(done)
+                testPublisher.Publish(getQueueName(notificationsQueue))
+            }()
+            close(notificationsCh)
+            select {
+            case <-done:
+                Succeed()
+            case <-time.After(timeout):
+                Fail("Publisher did not exit within timeout")
+            }
+        })
+
+        It("will survive an empty Message", func() {
+            go testPublisher.Publish(getQueueName(notificationsQueue))
+            notificationsCh <- pubsub.EventErrorMessage{}
+            close(notificationsCh)
+            getSqsMessage(getQueueName(notificationsQueue))
+        })
+
+        It("will send several messages within a reasonable timeframe", func() {
+            go testPublisher.Publish(getQueueName(notificationsQueue))
+            for i := range [10]int{} {
+                msg := pubsub.EventMessage{
+                    Sender:         "someone",
+                    Destination:    fmt.Sprintf("dest-%d", i),
+                    EventId:        fmt.Sprintf("evt-%d", i),
+                    EventName:      "many-messages-test",
+                    EventTimestamp: time.Now(),
+                }
+                detail := "more details about the error"
+                notificationsCh <- *pubsub.ErrorMessageWithDetail(fmt.Errorf("this is a test"), &msg, detail)
+            }
+            done := make(chan interface{})
+            go func() {
+                defer close(done)
+                for range [10]int{} {
+                    res := getSqsMessage(getQueueName(notificationsQueue))
+                    Expect(res).ToNot(BeNil())
+                    body := *res.Body
+                    var sentMsg pubsub.EventMessage
+                    Expect(json.Unmarshal([]byte(body), &sentMsg)).ToNot(HaveOccurred())
+                    Expect(sentMsg.EventName).To(Equal("many-messages-test"))
+                }
+            }()
+            close(notificationsCh)
+            select {
+            case <-done:
+                Succeed()
+            case <-time.After(timeout):
+                Fail("timed out waiting for Publisher to exit")
+            }
+        })
+    })
+})

--- a/pubsub/sqs_sub.go
+++ b/pubsub/sqs_sub.go
@@ -19,15 +19,19 @@
 package pubsub
 
 import (
+    "fmt"
     "github.com/aws/aws-sdk-go/aws"
     "github.com/aws/aws-sdk-go/aws/session"
     "github.com/aws/aws-sdk-go/service/sqs"
     "github.com/massenz/go-statemachine/logging"
+    "os"
     "strconv"
     "time"
 )
 
-// FIXME: need to generalize and abstract the implementation of a Subscriber
+// TODO: should we need to generalize and abstract the implementation of a Subscriber?
+//  This would be necessary if we were to implement a different message broker (e.g., Kafka)
+
 type SqsSubscriber struct {
     logger          *logging.Log
     client          *sqs.SQS
@@ -38,11 +42,27 @@ type SqsSubscriber struct {
 
 // NewSqsSubscriber will create a new `Subscriber` to listen to
 // incoming api.Event from a SQS `queue`.
-func NewSqsSubscriber(eventsChannel chan<- EventMessage) *SqsSubscriber {
-    // TODO: need to confirm this works when running inside an EKS Node.
-    sess := session.Must(session.NewSessionWithOptions(session.Options{
-        SharedConfigState: session.SharedConfigEnable,
-    }))
+func NewSqsSubscriber(eventsChannel chan<- EventMessage, sqsUrl *string) *SqsSubscriber {
+    var sess *session.Session
+    if sqsUrl == nil {
+        sess = session.Must(session.NewSessionWithOptions(session.Options{
+            SharedConfigState: session.SharedConfigEnable,
+        }))
+    } else {
+        region, found := os.LookupEnv("AWS_REGION")
+        if !found {
+            fmt.Printf("No AWS Region configured, cannot connect to SQS provider at %s\n",
+                *sqsUrl)
+            return nil
+        }
+        sess = session.Must(session.NewSessionWithOptions(session.Options{
+            SharedConfigState: session.SharedConfigEnable,
+            Config: aws.Config{
+                Endpoint: sqsUrl,
+                Region:   &region,
+            },
+        }))
+    }
     client := sqs.New(sess)
     return &SqsSubscriber{
         logger:          logging.NewLog("SQS-Sub"),
@@ -58,30 +78,20 @@ func (s *SqsSubscriber) SetLogLevel(level logging.LogLevel) {
     s.logger.Level = level
 }
 
-// GetQueueUrlFromTopic retrieves from AWS SQS the URL for the queue, given the topic name
-func (s *SqsSubscriber) GetQueueUrlFromTopic(topic string) (*string, error) {
-    out, err := s.client.GetQueueUrl(&sqs.GetQueueUrlInput{
-        QueueName: &topic,
-    })
-    if err != nil {
-        s.logger.Error("Cannot obtain URL for SQS Topic %s: %v", topic, err)
-        return nil, err
-    }
-    return out.QueueUrl, nil
-}
-
 // Subscribe runs until signaled on the Done channel and listens for incoming Events
-func (s *SqsSubscriber) Subscribe(topic string) {
-    queueUrl, err := s.GetQueueUrlFromTopic(topic)
-    if err != nil {
-        // From the Google School: fail fast and noisily from an unrecoverable error
-        panic(err)
-    }
-    s.logger.Info("SQS Subscriber started for queue: %s", *queueUrl)
+func (s *SqsSubscriber) Subscribe(topic string, done <-chan interface{}) {
+    queueUrl := GetQueueUrl(s.client, topic)
+    s.logger.Info("SQS Subscriber started for queue: %s", queueUrl)
 
     timeout := int64(s.Timeout.Seconds())
-    // This will run forever until the server is terminated.
     for {
+        select {
+        case <-done:
+            s.logger.Info("SQS Subscriber terminating")
+            return
+        default:
+            s.logger.Trace("...")
+        }
         start := time.Now()
         s.logger.Trace("Polling SQS at %v", start)
         msgResult, err := s.client.ReceiveMessage(&sqs.ReceiveMessageInput{
@@ -91,7 +101,7 @@ func (s *SqsSubscriber) Subscribe(topic string) {
             MessageAttributeNames: []*string{
                 aws.String(sqs.QueueAttributeNameAll),
             },
-            QueueUrl:            queueUrl,
+            QueueUrl:            &queueUrl,
             MaxNumberOfMessages: aws.Int64(10),
             VisibilityTimeout:   &timeout,
         })
@@ -103,7 +113,7 @@ func (s *SqsSubscriber) Subscribe(topic string) {
             }
             for _, msg := range msgResult.Messages {
                 s.logger.Trace("processing %v", msg.String())
-                go s.ProcessMessage(msg, queueUrl)
+                go s.ProcessMessage(msg, &queueUrl)
             }
         } else {
             s.logger.Error(err.Error())
@@ -117,7 +127,7 @@ func (s *SqsSubscriber) Subscribe(topic string) {
 }
 
 func (s *SqsSubscriber) ProcessMessage(msg *sqs.Message, queueUrl *string) {
-
+    s.logger.Trace("Processing Message %v", msg.MessageId)
     var event = EventMessage{}
     event.Destination = *msg.MessageAttributes["DestinationId"].StringValue
     event.EventName = *msg.Body
@@ -127,8 +137,10 @@ func (s *SqsSubscriber) ProcessMessage(msg *sqs.Message, queueUrl *string) {
         event.Sender = *msg.MessageAttributes["Sender"].StringValue
         timestamp := msg.Attributes[sqs.MessageSystemAttributeNameSentTimestamp]
         if timestamp == nil {
+            s.logger.Warn("No Timestamp in received event, using current time")
             event.EventTimestamp = time.Now()
         } else {
+            // An SQS Message timestamp is a Unix milliseconds from epoch.
             // TODO: We may need some amount of error-checking here.
             ts, _ := strconv.ParseInt(*timestamp, 10, 64)
             event.EventTimestamp = time.UnixMilli(ts)
@@ -136,8 +148,10 @@ func (s *SqsSubscriber) ProcessMessage(msg *sqs.Message, queueUrl *string) {
         s.logger.Debug("Sent at: %s", event.EventTimestamp.String())
         s.events <- event
     } else {
-        // TODO: publish error to DLQ, no point in retrying.
-        s.logger.Error("No Destination ID or Event in %v", msg.String())
+        errDetails := fmt.Sprintf("No Destination ID or Event in %v", msg.String())
+        s.logger.Error(errDetails)
+        ErrorMessage(fmt.Errorf(errDetails), &event)
+        // TODO: publish error to DLQ.
     }
 
     s.logger.Debug("Removing message %v from SQS", *msg.MessageId)
@@ -146,8 +160,10 @@ func (s *SqsSubscriber) ProcessMessage(msg *sqs.Message, queueUrl *string) {
         ReceiptHandle: msg.ReceiptHandle,
     })
     if err != nil {
-        // TODO: publish error to DLQ, we should probably also alert.
-        s.logger.Error("Failed to remove message %v from SQS: %v", msg.MessageId, err)
+        errDetails := fmt.Sprintf("Failed to remove message %v from SQS", msg.MessageId)
+        s.logger.Error("%s: %v", errDetails, err)
+        ErrorMessageWithDetail(err, &event, errDetails)
+        // TODO: publish error to DLQ, should also retry removal here.
     }
-    s.logger.Trace("Message removed")
+    s.logger.Trace("Message %v removed", msg.MessageId)
 }

--- a/pubsub/sqs_sub_test.go
+++ b/pubsub/sqs_sub_test.go
@@ -1,0 +1,65 @@
+package pubsub_test
+
+import (
+    "time"
+
+    . "github.com/JiaYongfei/respect/gomega"
+    . "github.com/onsi/ginkgo"
+    . "github.com/onsi/gomega"
+
+    log "github.com/massenz/go-statemachine/logging"
+    "github.com/massenz/go-statemachine/pubsub"
+)
+
+var _ = Describe("SQS Subscriber", func() {
+
+    Context("when correctly initialized", func() {
+        var (
+            testSubscriber *pubsub.SqsSubscriber
+            eventsCh       chan pubsub.EventMessage
+        )
+        BeforeEach(func() {
+            eventsCh = make(chan pubsub.EventMessage)
+            testSubscriber = pubsub.NewSqsSubscriber(eventsCh, &sqsUrl)
+            Expect(testSubscriber).ToNot(BeNil())
+            // Set to DEBUG when diagnosing failing tests
+            testSubscriber.SetLogLevel(log.NONE)
+            // Make it exit much sooner in tests
+            d, _ := time.ParseDuration("200msec")
+            testSubscriber.PollingInterval = d
+        })
+        It("receives events", func() {
+            msg := pubsub.EventMessage{
+                Sender:      "me",
+                Destination: "some-fsm",
+                EventId:     "feed-beef",
+                EventName:   "test-me",
+            }
+            Expect(postSqsMessage(getQueueName(eventsQueue), &msg)).ToNot(HaveOccurred())
+            done := make(chan interface{})
+            doneTesting := make(chan interface{})
+            go func() {
+                defer close(done)
+                testSubscriber.Subscribe(getQueueName(eventsQueue), doneTesting)
+            }()
+
+            select {
+            case event := <-eventsCh:
+                testLog.Debug("Received Event -- Timestamp: %v", event.EventTimestamp)
+                // Workaround as we can't set the time sent
+                msg.EventTimestamp = event.EventTimestamp
+                Expect(event).To(Respect(msg))
+                close(doneTesting)
+            case <-time.After(timeout):
+                Fail("timed out waiting to receive a message")
+            }
+
+            select {
+            case <-done:
+                Succeed()
+            case <-time.After(timeout):
+                Fail("timed out waiting for the subscriber to exit")
+            }
+        })
+    })
+})

--- a/pubsub/types.go
+++ b/pubsub/types.go
@@ -21,6 +21,8 @@ package pubsub
 import (
     "encoding/json"
     "fmt"
+    "github.com/massenz/go-statemachine/logging"
+    "github.com/massenz/go-statemachine/storage"
     "time"
 )
 
@@ -28,10 +30,10 @@ import (
 // message broker implementation.  It is the Internal Representation (
 // IR) for an event being originated by the `sender` and being sent to a `Destination` StateMachine.
 type EventMessage struct {
-    Sender         string    `json:"sender"`
-    Destination    string    `json:"destination"`
-    EventId        string    `json:"event_id"`
-    EventName      string    `json:"event_name"`
+    Sender         string    `json:"sender,omitempty"`
+    Destination    string    `json:"destination,omitempty"`
+    EventId        string    `json:"event_id,omitempty"`
+    EventName      string    `json:"event_name,omitempty"`
     EventTimestamp time.Time `json:"timestamp"`
 }
 
@@ -48,6 +50,13 @@ type EventProcessingError struct {
     err error
 }
 
+func (epe *EventProcessingError) Error() string {
+    if epe.err != nil {
+        return epe.err.Error()
+    }
+    return ""
+}
+
 // MarshalJSON Amazingly enough, `json` does not know how to Marshal an error; MarshalJSON for the
 // EventProcessingError fills the gap,
 // so we can serialize an EventErrorMessage with the embedded error.
@@ -55,7 +64,7 @@ func (epe EventProcessingError) MarshalJSON() ([]byte, error) {
     return json.Marshal(epe.err.Error())
 }
 
-// UnmarshalJSON is the opposite of MarshalJSON and reads in an error description.
+// UnmarshalJSON is the inverse of MarshalJSON and reads in an error description.
 // By convention, if the passed in string is `null` this is a no-op.
 func (epe EventProcessingError) UnmarshalJSON(data []byte) error {
     s := string(data)
@@ -72,17 +81,44 @@ func NewEventProcessingError(err error) *EventProcessingError {
 // An EventErrorMessage encapsulates an error occurred while processing the `Message` and is
 // returned over the `notifications` channel to a `Publisher` for eventual upstream processing.
 type EventErrorMessage struct {
-    Error       EventProcessingError `json:"error"`
-    ErrorDetail string               `json:"detail"` // optional
-    Message     *EventMessage        `json:"message"`
+    Error       EventProcessingError `json:"error,omitempty"`
+    ErrorDetail string               `json:"detail,omitempty"` // optional
+    Message     *EventMessage        `json:"message,omitempty"`
 }
 
 func (m *EventErrorMessage) String() string {
+    // FIXME: this probably needs a better approach to omit JSON entirely as apparently
+    //  `omitempty` does not work here (and json.Marshal() panics for nil elements).
+    if m.Message == nil {
+        m.Message = &EventMessage{}
+    }
+    if m.Error.err == nil {
+        m.Error.err = fmt.Errorf("no error")
+    }
     s, err := json.Marshal(*m)
     if err != nil {
         return err.Error()
     }
     return string(s)
+}
+
+// ErrorMessageWithDetail creates a new EventErrorMessage from the given error and detail (optional,
+// can be nil) and an optional EventMessage (can be nil).
+// Modeled on the fmt.Error() function.
+func ErrorMessageWithDetail(err error, msg *EventMessage, detail string) *EventErrorMessage {
+    ret := EventErrorMessage{
+        Error:   EventProcessingError{err: err},
+        Message: msg,
+    }
+    if detail != "" {
+        ret.ErrorDetail = detail
+    }
+    return &ret
+}
+
+// ErrorMessage creates a new EventErrorMessage from the given error and an EventMessage (can be nil).
+func ErrorMessage(err error, msg *EventMessage) *EventErrorMessage {
+    return ErrorMessageWithDetail(err, msg, "")
 }
 
 // Not really "variables" - but Go is too dumb to figure out they're actually constants.
@@ -95,3 +131,22 @@ var (
     // See: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
     DefaultVisibilityTimeout, _ = time.ParseDuration("5s")
 )
+
+// An EventsListener will process EventMessage in a separate goroutine.
+// The messages are posted on an `events` channel, and if any error is encountered,
+// error messages are posted on a `notifications` channel for further processing upstream.
+type EventsListener struct {
+    logger        *logging.Log
+    events        <-chan EventMessage
+    notifications chan<- EventErrorMessage
+    store         storage.StoreManager
+}
+
+// ListenerOptions are used to configure an EventsListener at creation and are used
+// to decouple the internals of the listener from its exposed configuration.
+type ListenerOptions struct {
+    EventsChannel        <-chan EventMessage
+    NotificationsChannel chan<- EventErrorMessage
+    StatemachinesStore   storage.StoreManager
+    ListenersPoolSize    int8
+}

--- a/server/config_handlers.go
+++ b/server/config_handlers.go
@@ -42,7 +42,7 @@ func CreateConfigurationHandler(w http.ResponseWriter, r *http.Request) {
     }
     logger.Debug("Creating new configuration with Version ID: %s", config.GetVersionId())
 
-    // TODO PAB-99: Check this configuration does not already exist.
+    // TODO: Check this configuration does not already exist.
 
     err = config.CheckValid()
     if err != nil {
@@ -60,7 +60,7 @@ func CreateConfigurationHandler(w http.ResponseWriter, r *http.Request) {
 
     w.Header().Add("Location", ConfigurationsEndpoint+"/"+config.GetVersionId())
     w.WriteHeader(http.StatusCreated)
-    err = json.NewEncoder(w).Encode(config)
+    err = json.NewEncoder(w).Encode(&config)
     if err != nil {
         http.Error(w, err.Error(), http.StatusInternalServerError)
         return

--- a/server/config_handlers_test.go
+++ b/server/config_handlers_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Configuration Handlers", func() {
         router = server.NewRouter()
     )
     // Disabling verbose logging, as it pollutes test output;
-    // set it back to DEBUG when tests fail and you need to
+    // set it back to DEBUG when tests fail, and you need to
     // diagnose the failure.
     server.SetLogLevel(log.WARN)
 

--- a/server/health_handler.go
+++ b/server/health_handler.go
@@ -30,7 +30,7 @@ func HealthHandler(w http.ResponseWriter, r *http.Request) {
     defer trace(r.RequestURI)()
     defaultContent(w)
 
-    // TODO @MM: add a check on Redis and SQS reachability
+    // TODO: add a check on Redis and SQS reachability
     res := MessageResponse{"UP"}
     err := json.NewEncoder(w).Encode(res)
     if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -66,7 +66,7 @@ func SetLogLevel(level log.LogLevel) {
 // that path params are testable.
 func NewRouter() *mux.Router {
 
-    // TODO @MM: Move all the Handlers to a `handlers` package.
+    // TODO: Move all the Handlers to a `handlers` package.
     r := mux.NewRouter()
     r.HandleFunc(HealthEndpoint, HealthHandler).Methods("GET")
     r.HandleFunc(ConfigurationsEndpoint, CreateConfigurationHandler).Methods("POST")

--- a/server/statemachine_handlers_test.go
+++ b/server/statemachine_handlers_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Statemachine Handlers", func() {
         router = server.NewRouter()
     )
     // Disabling verbose logging, as it pollutes test output;
-    // set it back to DEBUG when tests fail and you need to
+    // set it back to DEBUG when tests fail, and you need to
     // diagnose the failure.
     server.SetLogLevel(log.WARN)
 

--- a/server/types.go
+++ b/server/types.go
@@ -30,7 +30,7 @@ const (
 )
 
 // MessageResponse is returned when a more appropriate response is not available.
-// TODO @MM: Use this to implement better error handling
+// TODO: Use this to implement better error handling
 type MessageResponse struct {
     Msg string `json:"message"`
 }

--- a/storage/redis_store.go
+++ b/storage/redis_store.go
@@ -54,8 +54,7 @@ func NewRedisStore(address string, db int) StoreManager {
         logger: logging.NewLog(fmt.Sprintf("redis:%s", address)),
         client: redis.NewClient(&redis.Options{
             Addr: address,
-            // TODO @MM: understand what other int values mean
-            DB: db, // 0 means default DB
+            DB:   db, // 0 means default DB
         }),
         Timeout: DefaultTimeout,
     }

--- a/storage/types.go
+++ b/storage/types.go
@@ -33,8 +33,8 @@ type ConfigurationStorageManager interface {
 }
 
 type FiniteStateMachineStorageManager interface {
-    GetStateMachine(id string) (cfg *api.FiniteStateMachine, ok bool)
-    PutStateMachine(id string, cfg *api.FiniteStateMachine) (err error)
+    GetStateMachine(id string) (fsm *api.FiniteStateMachine, ok bool)
+    PutStateMachine(id string, fsm *api.FiniteStateMachine) (err error)
 }
 
 type StoreManager interface {


### PR DESCRIPTION
This PR completes the ability for SM to receive `Events` and publish `Notifications` to SQS.
Test coverage mostly exceeds 70% for all packages, excluding the `api` package, due to the fact that it is mostly made up of Protobuf generated classes (and also we are not testing all the marshal/unmarshal JSON code).

```
api      coverage: 27.2%
pubsub   coverage: 81.0%
server   coverage: 73.5%
storage  coverage: 81.6%
```

This needs to be tested using two containers running, Redis and Localstack (see the `Dockercompose.yaml` spec); use `make test` to replicate.