### PR TITLE
[ENG-430] Addresses intermittent Redis timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ compile:
                --go-grpc_opt=paths=source_relative \
                protos/*.proto
 
-all: compile cmd/server.go
-	go build -o $(out) cmd/server.go
+all: compile cmd/main.go
+	go build -o $(out) cmd/main.go
 	@chmod +x $(out)
 
 services:

--- a/api/statemachine_test.go
+++ b/api/statemachine_test.go
@@ -29,7 +29,10 @@ import (
 )
 
 var _ = Describe("FSM Protocol Buffers", func() {
-    BeforeEach(func() { Logger = log.NullLog })
+    BeforeEach(func() {
+        Logger = log.NewLog("statemachine-test")
+        Logger.Level = log.NONE
+    })
     Context("if well defined", func() {
         It("can be initialized", func() {
             var spaceship = Configuration{

--- a/build.settings
+++ b/build.settings
@@ -1,4 +1,3 @@
 # Build configuration
 
 version = 0.3.1
-

--- a/build.settings
+++ b/build.settings
@@ -1,3 +1,4 @@
 # Build configuration
 
 version = 0.3.1
+

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,6 +85,8 @@ func main() {
         "The name of the Dead-Letter Queue ("+"DLQ) in SQS to post errors to; if not "+
             "specified, the DLQ will not be used")
     var grpcPort = flag.Int("grpc-port", 7398, "The port for the gRPC server")
+    var maxRetries = flag.Int("max-retries", storage.DefaultMaxRetries,
+        "Max number of attempts for a recoverable error to be retried against the Redis cluster")
     var timeout = flag.Duration("timeout", storage.DefaultTimeout,
         "Timeout for Redis (as a Duration string, e.g. 1s, 20ms, etc.)")
     flag.Parse()
@@ -102,7 +104,8 @@ func main() {
         store = storage.NewInMemoryStore()
     } else {
         logger.Info("Connecting to Redis server at %s", *redisUrl)
-        store = storage.NewRedisStore(*redisUrl, 1, *timeout)
+        logger.Info("with timeout: %s, max-retries: %d", *timeout, *maxRetries)
+        store = storage.NewRedisStore(*redisUrl, 1, *timeout, *maxRetries)
     }
     server.SetStore(store)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,6 +85,8 @@ func main() {
         "The name of the Dead-Letter Queue ("+"DLQ) in SQS to post errors to; if not "+
             "specified, the DLQ will not be used")
     var grpcPort = flag.Int("grpc-port", 7398, "The port for the gRPC server")
+    var timeout = flag.Duration("timeout", storage.DefaultTimeout,
+        "Timeout for Redis (as a Duration string, e.g. 1s, 20ms, etc.)")
     flag.Parse()
 
     if *localOnly {
@@ -100,7 +102,7 @@ func main() {
         store = storage.NewInMemoryStore()
     } else {
         logger.Info("Connecting to Redis server at %s", *redisUrl)
-        store = storage.NewRedisStore(*redisUrl, 1)
+        store = storage.NewRedisStore(*redisUrl, 1, *timeout)
     }
     server.SetStore(store)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,16 +5,15 @@
 # NOTE: Use the Ubuntu image, others will encounter errors,
 #       including the "`GLIBC_2.32' not found" error.
 FROM  ubuntu:22.04
-WORKDIR /app
-
-COPY build/bin/sm-server docker/entrypoint.sh ./
 
 RUN groupadd -r sm-bot && useradd -r -g sm-bot sm-bot
-RUN apt-get update
-RUN apt-get install ca-certificates -y
+RUN apt-get update && apt-get install ca-certificates -y
+
+WORKDIR /app
+
 ADD docker/aws-credentials /home/sm-bot/.aws/credentials
-RUN chmod +x entrypoint.sh
-RUN chown sm-bot:sm-bot entrypoint.sh
+COPY build/bin/sm-server docker/entrypoint.sh ./
+RUN chmod a+x entrypoint.sh
 
 USER sm-bot
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,11 +26,11 @@ then
 fi
 
 echo -e "./sm-server -port ${SERVER_PORT}  ${endpoint:-} ${DEBUG}\n\
-    -redis ${REDIS}:${REDIS_PORT} -timeout ${TIMEOUT:-25ms}\n\
+    -redis ${REDIS}:${REDIS_PORT} -timeout ${TIMEOUT:-25ms} -max-retries ${RETRIES:-3}\n\
     -events ${EVENTS_Q} -errors ${ERRORS_Q}\n\
     $@"
 
 ./sm-server -http-port "${SERVER_PORT}"  ${endpoint:-} ${DEBUG} \
-    -redis ${REDIS}:${REDIS_PORT} -timeout ${TIMEOUT:-25ms} \
+    -redis ${REDIS}:${REDIS_PORT} -timeout ${TIMEOUT:-25ms} -max-retries ${RETRIES:-3} \
     -events "${EVENTS_Q}" -errors "${ERRORS_Q}" \
     "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -25,12 +25,12 @@ then
   endpoint="--endpoint-url ${AWS_ENDPOINT}"
 fi
 
-echo "./sm-server -port ${SERVER_PORT}  ${endpoint:-} ${DEBUG} \
-    -redis ${REDIS}:${REDIS_PORT} \
-    -events ${EVENTS_Q} -errors ${ERRORS_Q}"
-echo "$@"
+echo -e "./sm-server -port ${SERVER_PORT}  ${endpoint:-} ${DEBUG}\n\
+    -redis ${REDIS}:${REDIS_PORT} -timeout ${TIMEOUT:-25ms}\n\
+    -events ${EVENTS_Q} -errors ${ERRORS_Q}\n\
+    $@"
 
 ./sm-server -http-port "${SERVER_PORT}"  ${endpoint:-} ${DEBUG} \
-    -redis ${REDIS}:${REDIS_PORT} \
+    -redis ${REDIS}:${REDIS_PORT} -timeout ${TIMEOUT:-25ms} \
     -events "${EVENTS_Q}" -errors "${ERRORS_Q}" \
     "$@"

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/massenz/slf4go v0.1.1-gd1a5998
+	github.com/massenz/slf4go v0.3.1-gb35df61
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	google.golang.org/grpc v1.32.0
@@ -28,4 +28,5 @@ require (
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/massenz/slf4go v0.1.1-gd1a5998 h1:sXODxQ9HxPkbRvS0tsssrGtvV0rfNxRUrQnS7WkG5sk=
 github.com/massenz/slf4go v0.1.1-gd1a5998/go.mod h1:LYuqnSMv0FrjFqD7uWEd/oZjuYf0MH9ukqt91bjBxhI=
+github.com/massenz/slf4go v0.3.1-gb35df61 h1:X/rcmd918F2nkkPbahMcQE0Qb8wc6xg37rpsfunjGMM=
+github.com/massenz/slf4go v0.3.1-gb35df61/go.mod h1:ZJjthXAnZMJGwXUz3Z3v5uyban00uAFFoDYODOoLFpw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -182,5 +184,7 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/grpc/grpc_server_test.go
+++ b/grpc/grpc_server_test.go
@@ -1,220 +1,222 @@
 package grpc_test
 
 import (
-	"context"
-	"fmt"
-	. "github.com/JiaYongfei/respect/gomega"
-	"github.com/massenz/go-statemachine/api"
-	"github.com/massenz/go-statemachine/pubsub"
-	"github.com/massenz/go-statemachine/storage"
-	"github.com/massenz/slf4go/logging"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+    "context"
+    "fmt"
+    . "github.com/JiaYongfei/respect/gomega"
+    "github.com/massenz/go-statemachine/api"
+    "github.com/massenz/go-statemachine/pubsub"
+    "github.com/massenz/go-statemachine/storage"
+    "github.com/massenz/slf4go/logging"
+    . "github.com/onsi/ginkgo"
+    . "github.com/onsi/gomega"
 
-	g "google.golang.org/grpc"
-	"net"
-	"time"
+    g "google.golang.org/grpc"
+    "net"
+    "time"
 
-	"github.com/massenz/go-statemachine/grpc"
+    "github.com/massenz/go-statemachine/grpc"
 )
 
 var _ = Describe("GrpcServer", func() {
 
-	Context("when configured", func() {
-		var testCh chan pubsub.EventMessage
-		var listener net.Listener
-		var client api.StatemachineServiceClient
-		var done func()
-		var store = storage.NewInMemoryStore()
-		store.SetLogLevel(logging.NONE)
+    Context("when configured", func() {
+        var testCh chan pubsub.EventMessage
+        var listener net.Listener
+        var client api.StatemachineServiceClient
+        var done func()
+        var store = storage.NewInMemoryStore()
+        store.SetLogLevel(logging.NONE)
 
-		BeforeEach(func() {
-			var err error
-			testCh = make(chan pubsub.EventMessage, 5)
-			listener, err = net.Listen("tcp", ":0")
-			Ω(err).ShouldNot(HaveOccurred())
+        BeforeEach(func() {
+            var err error
+            testCh = make(chan pubsub.EventMessage, 5)
+            listener, err = net.Listen("tcp", ":0")
+            Ω(err).ShouldNot(HaveOccurred())
 
-			cc, err := g.Dial(listener.Addr().String(), g.WithInsecure())
-			Ω(err).ShouldNot(HaveOccurred())
+            cc, err := g.Dial(listener.Addr().String(), g.WithInsecure())
+            Ω(err).ShouldNot(HaveOccurred())
 
-			client = api.NewStatemachineServiceClient(cc)
-			server, err := grpc.NewGrpcServer(&grpc.Config{
-				EventsChannel: testCh,
-				Store:         store,
-				Logger:        logging.NullLog,
-			})
-			Ω(err).ToNot(HaveOccurred())
-			Ω(server).ToNot(BeNil())
+            client = api.NewStatemachineServiceClient(cc)
+            l := logging.NewLog("grpc-server-test")
+            l.Level = logging.NONE
+            server, err := grpc.NewGrpcServer(&grpc.Config{
+                EventsChannel: testCh,
+                Store:         store,
+                Logger:        l,
+            })
+            Ω(err).ToNot(HaveOccurred())
+            Ω(server).ToNot(BeNil())
 
-			go func() {
-				Ω(server.Serve(listener)).Should(Succeed())
-			}()
-			done = func() {
-				server.Stop()
-				cc.Close()
-				listener.Close()
-			}
-		})
+            go func() {
+                Ω(server.Serve(listener)).Should(Succeed())
+            }()
+            done = func() {
+                server.Stop()
+                cc.Close()
+                listener.Close()
+            }
+        })
 
-		It("should process events", func() {
-			response, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
-				Event: &api.Event{
-					EventId: "1",
-					Transition: &api.Transition{
-						Event: "test-vt",
-					},
-					Originator: "test",
-				},
-				Dest: "2",
-			})
-			Ω(err).ToNot(HaveOccurred())
-			Ω(response).ToNot(BeNil())
-			Ω(response.EventId).To(Equal("1"))
-			done()
-			select {
-			case evt := <-testCh:
-				Ω(evt.EventId).To(Equal("1"))
-				Ω(evt.EventName).To(Equal("test-vt"))
-				Ω(evt.Sender).To(Equal("test"))
-				Ω(evt.Destination).To(Equal("2"))
-			case <-time.After(10 * time.Millisecond):
-				Fail("Timed out")
+        It("should process events", func() {
+            response, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
+                Event: &api.Event{
+                    EventId: "1",
+                    Transition: &api.Transition{
+                        Event: "test-vt",
+                    },
+                    Originator: "test",
+                },
+                Dest: "2",
+            })
+            Ω(err).ToNot(HaveOccurred())
+            Ω(response).ToNot(BeNil())
+            Ω(response.EventId).To(Equal("1"))
+            done()
+            select {
+            case evt := <-testCh:
+                Ω(evt.EventId).To(Equal("1"))
+                Ω(evt.EventName).To(Equal("test-vt"))
+                Ω(evt.Sender).To(Equal("test"))
+                Ω(evt.Destination).To(Equal("2"))
+            case <-time.After(10 * time.Millisecond):
+                Fail("Timed out")
 
-			}
-		})
-		It("should create an ID for events without", func() {
-			response, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
-				Event: &api.Event{
-					Transition: &api.Transition{
-						Event: "test-vt",
-					},
-					Originator: "test",
-				},
-				Dest: "123456",
-			})
-			Ω(err).ToNot(HaveOccurred())
-			Ω(response.EventId).ToNot(BeNil())
-			generatedId := response.EventId
-			done()
-			select {
-			case evt := <-testCh:
-				Ω(evt.EventId).Should(Equal(generatedId))
-				Ω(evt.EventName).To(Equal("test-vt"))
-			case <-time.After(10 * time.Millisecond):
-				Fail("Timed out")
-			}
-		})
-		It("should fail for missing destination", func() {
-			_, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
-				Event: &api.Event{
-					Transition: &api.Transition{
-						Event: "test-vt",
-					},
-					Originator: "test",
-				},
-			})
-			Ω(err).To(HaveOccurred())
-			done()
-			select {
-			case evt := <-testCh:
-				Fail(fmt.Sprintf("Unexpected event: %s", evt))
-			case <-time.After(10 * time.Millisecond):
-				Succeed()
-			}
-		})
-		It("should fail for missing event", func() {
-			_, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
-				Event: &api.Event{
-					Transition: &api.Transition{
-						Event: "",
-					},
-					Originator: "test",
-				},
-				Dest: "9876",
-			})
-			Ω(err).To(HaveOccurred())
-			done()
-			select {
-			case evt := <-testCh:
-				Fail(fmt.Sprintf("UnΩed event: %s", evt))
-			case <-time.After(10 * time.Millisecond):
-				Succeed()
-			}
-		})
+            }
+        })
+        It("should create an ID for events without", func() {
+            response, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
+                Event: &api.Event{
+                    Transition: &api.Transition{
+                        Event: "test-vt",
+                    },
+                    Originator: "test",
+                },
+                Dest: "123456",
+            })
+            Ω(err).ToNot(HaveOccurred())
+            Ω(response.EventId).ToNot(BeNil())
+            generatedId := response.EventId
+            done()
+            select {
+            case evt := <-testCh:
+                Ω(evt.EventId).Should(Equal(generatedId))
+                Ω(evt.EventName).To(Equal("test-vt"))
+            case <-time.After(10 * time.Millisecond):
+                Fail("Timed out")
+            }
+        })
+        It("should fail for missing destination", func() {
+            _, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
+                Event: &api.Event{
+                    Transition: &api.Transition{
+                        Event: "test-vt",
+                    },
+                    Originator: "test",
+                },
+            })
+            Ω(err).To(HaveOccurred())
+            done()
+            select {
+            case evt := <-testCh:
+                Fail(fmt.Sprintf("Unexpected event: %s", evt))
+            case <-time.After(10 * time.Millisecond):
+                Succeed()
+            }
+        })
+        It("should fail for missing event", func() {
+            _, err := client.ConsumeEvent(context.Background(), &api.EventRequest{
+                Event: &api.Event{
+                    Transition: &api.Transition{
+                        Event: "",
+                    },
+                    Originator: "test",
+                },
+                Dest: "9876",
+            })
+            Ω(err).To(HaveOccurred())
+            done()
+            select {
+            case evt := <-testCh:
+                Fail(fmt.Sprintf("UnΩed event: %s", evt))
+            case <-time.After(10 * time.Millisecond):
+                Succeed()
+            }
+        })
 
-		// Store management tests
-		var cfg *api.Configuration
-		var fsm *api.FiniteStateMachine
-		BeforeEach(func() {
-			cfg = &api.Configuration{
-				Name:    "test-conf",
-				Version: "v1",
-				States:  []string{"start", "stop"},
-				Transitions: []*api.Transition{
-					{From: "start", To: "stop", Event: "shutdown"},
-				},
-				StartingState: "start",
-			}
-			fsm = &api.FiniteStateMachine{ConfigId: cfg.GetVersionId()}
-		})
-		It("should store valid configurations", func() {
-			_, ok := store.GetConfig(cfg.GetVersionId())
-			Ω(ok).To(BeFalse())
-			response, err := client.PutConfiguration(context.Background(), cfg)
-			Ω(err).ToNot(HaveOccurred())
-			Ω(response).ToNot(BeNil())
-			Ω(response.Id).To(Equal(cfg.GetVersionId()))
-			found, ok := store.GetConfig(response.Id)
-			Ω(ok).Should(BeTrue())
-			Ω(found).Should(Respect(cfg))
-		})
-		It("should fail for invalid configuration", func() {
-			invalid := &api.Configuration{
-				Name:          "invalid",
-				Version:       "v1",
-				States:        []string{},
-				Transitions:   nil,
-				StartingState: "",
-			}
-			_, err := client.PutConfiguration(context.Background(), invalid)
-			Ω(err).To(HaveOccurred())
-		})
-		It("should retrieve a valid configuration", func() {
-			Ω(store.PutConfig(cfg.GetVersionId(), cfg)).To(Succeed())
-			response, err := client.GetConfiguration(context.Background(),
-				&api.GetRequest{Id: cfg.GetVersionId()})
-			Ω(err).ToNot(HaveOccurred())
-			Ω(response).ToNot(BeNil())
-			Ω(response).Should(Respect(cfg))
-		})
-		It("should return an empty configuration for an invalid ID", func() {
-			_, err := client.GetConfiguration(context.Background(), &api.GetRequest{Id: "fake"})
-			Ω(err).To(HaveOccurred())
-		})
+        // Store management tests
+        var cfg *api.Configuration
+        var fsm *api.FiniteStateMachine
+        BeforeEach(func() {
+            cfg = &api.Configuration{
+                Name:    "test-conf",
+                Version: "v1",
+                States:  []string{"start", "stop"},
+                Transitions: []*api.Transition{
+                    {From: "start", To: "stop", Event: "shutdown"},
+                },
+                StartingState: "start",
+            }
+            fsm = &api.FiniteStateMachine{ConfigId: cfg.GetVersionId()}
+        })
+        It("should store valid configurations", func() {
+            _, ok := store.GetConfig(cfg.GetVersionId())
+            Ω(ok).To(BeFalse())
+            response, err := client.PutConfiguration(context.Background(), cfg)
+            Ω(err).ToNot(HaveOccurred())
+            Ω(response).ToNot(BeNil())
+            Ω(response.Id).To(Equal(cfg.GetVersionId()))
+            found, ok := store.GetConfig(response.Id)
+            Ω(ok).Should(BeTrue())
+            Ω(found).Should(Respect(cfg))
+        })
+        It("should fail for invalid configuration", func() {
+            invalid := &api.Configuration{
+                Name:          "invalid",
+                Version:       "v1",
+                States:        []string{},
+                Transitions:   nil,
+                StartingState: "",
+            }
+            _, err := client.PutConfiguration(context.Background(), invalid)
+            Ω(err).To(HaveOccurred())
+        })
+        It("should retrieve a valid configuration", func() {
+            Ω(store.PutConfig(cfg.GetVersionId(), cfg)).To(Succeed())
+            response, err := client.GetConfiguration(context.Background(),
+                &api.GetRequest{Id: cfg.GetVersionId()})
+            Ω(err).ToNot(HaveOccurred())
+            Ω(response).ToNot(BeNil())
+            Ω(response).Should(Respect(cfg))
+        })
+        It("should return an empty configuration for an invalid ID", func() {
+            _, err := client.GetConfiguration(context.Background(), &api.GetRequest{Id: "fake"})
+            Ω(err).To(HaveOccurred())
+        })
 
-		It("should store a valid FSM", func() {
-			Ω(store.PutConfig(cfg.GetVersionId(), cfg)).To(Succeed())
-			resp, err := client.PutFiniteStateMachine(context.Background(), fsm)
-			Ω(err).ToNot(HaveOccurred())
-			Ω(resp).ToNot(BeNil())
-			Ω(resp.Id).ToNot(BeNil())
-			Ω(resp.Fsm).Should(Respect(fsm))
-		})
-		It("should fail with an invalid Config ID", func() {
-			invalid := &api.FiniteStateMachine{ConfigId: "fake"}
-			_, err := client.PutFiniteStateMachine(context.Background(), invalid)
-			Ω(err).Should(HaveOccurred())
-		})
-		It("can retrieve a stored FSM", func() {
-			id := "123456"
-			Ω(store.PutConfig(fsm.ConfigId, cfg))
-			Ω(store.PutStateMachine(id, fsm)).Should(Succeed())
-			Ω(client.GetFiniteStateMachine(context.Background(), &api.GetRequest{Id: id})).Should(
-				Respect(fsm))
-		})
-		It("will return an error for an invalid ID", func() {
-			_, err := client.GetFiniteStateMachine(context.Background(), &api.GetRequest{Id: "fake"})
-			Ω(err).Should(HaveOccurred())
-		})
-	})
+        It("should store a valid FSM", func() {
+            Ω(store.PutConfig(cfg.GetVersionId(), cfg)).To(Succeed())
+            resp, err := client.PutFiniteStateMachine(context.Background(), fsm)
+            Ω(err).ToNot(HaveOccurred())
+            Ω(resp).ToNot(BeNil())
+            Ω(resp.Id).ToNot(BeNil())
+            Ω(resp.Fsm).Should(Respect(fsm))
+        })
+        It("should fail with an invalid Config ID", func() {
+            invalid := &api.FiniteStateMachine{ConfigId: "fake"}
+            _, err := client.PutFiniteStateMachine(context.Background(), invalid)
+            Ω(err).Should(HaveOccurred())
+        })
+        It("can retrieve a stored FSM", func() {
+            id := "123456"
+            Ω(store.PutConfig(fsm.ConfigId, cfg))
+            Ω(store.PutStateMachine(id, fsm)).Should(Succeed())
+            Ω(client.GetFiniteStateMachine(context.Background(), &api.GetRequest{Id: id})).Should(
+                Respect(fsm))
+        })
+        It("will return an error for an invalid ID", func() {
+            _, err := client.GetFiniteStateMachine(context.Background(), &api.GetRequest{Id: "fake"})
+            Ω(err).Should(HaveOccurred())
+        })
+    })
 })

--- a/server/statemachine_handlers.go
+++ b/server/statemachine_handlers.go
@@ -42,7 +42,7 @@ func CreateStatemachineHandler(w http.ResponseWriter, r *http.Request) {
     }
     cfg, ok := storeManager.GetConfig(request.ConfigurationVersion)
     if !ok {
-        http.Error(w, "configuration not found", http.StatusNotAcceptable)
+        http.Error(w, "configuration not found", http.StatusNotFound)
         return
     }
     logger.Debug("Found configuration %s", cfg)

--- a/server/statemachine_handlers_test.go
+++ b/server/statemachine_handlers_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Handlers", func() {
 
             It("should fail", func() {
                 router.ServeHTTP(writer, req)
-                Expect(writer.Code).To(Equal(http.StatusNotAcceptable))
+                Expect(writer.Code).To(Equal(http.StatusNotFound))
                 location := writer.Header().Get("Location")
                 Expect(location).To(BeEmpty())
                 response := server.StateMachineResponse{}

--- a/storage/redis_store.go
+++ b/storage/redis_store.go
@@ -19,139 +19,141 @@
 package storage
 
 import (
-	"context"
-	"fmt"
-	"github.com/go-redis/redis/v8"
-	"github.com/massenz/go-statemachine/api"
-	log "github.com/massenz/slf4go/logging"
-	"time"
+    "context"
+    "fmt"
+    "github.com/go-redis/redis/v8"
+    "github.com/massenz/go-statemachine/api"
+    slf4go "github.com/massenz/slf4go/logging"
+    "time"
 )
 
 const (
-	NeverExpire      = 0
-	DefaultRedisPort = "6379"
-	DefaultRedisDb   = 0
+    NeverExpire      = 0
+    DefaultRedisPort = "6379"
+    DefaultRedisDb   = 0
 )
 
 var (
-	// Despite what Go thinks, yeah, this IS a constant
-	DefaultTimeout, _ = time.ParseDuration("200ms")
-	DefaultContext    = context.Background()
+    // Despite what Go thinks, yeah, this IS a constant
+    DefaultTimeout, _ = time.ParseDuration("200ms")
+    DefaultContext    = context.Background()
 )
 
 type RedisStore struct {
-	logger  *log.Log
-	client  *redis.Client
-	Timeout time.Duration
+    logger  *slf4go.Log
+    client  *redis.Client
+    Timeout time.Duration
 }
 
 func (csm *RedisStore) SetTimeout(duration time.Duration) {
-	csm.Timeout = duration
+    csm.Timeout = duration
 }
 
-func NewRedisStore(address string, db int) StoreManager {
-	return &RedisStore{
-		logger: log.NewLog(fmt.Sprintf("redis:%s", address)),
-		client: redis.NewClient(&redis.Options{
-			Addr: address,
-			DB:   db, // 0 means default DB
-		}),
-		Timeout: DefaultTimeout,
-	}
+func NewRedisStore(address string, db int, timeout time.Duration) StoreManager {
+    logger := slf4go.NewLog(fmt.Sprintf("redis://%s/%d", address, db))
+    logger.Info("Creating new RedisStore with timeout %s", timeout)
+    return &RedisStore{
+        logger: logger,
+        client: redis.NewClient(&redis.Options{
+            Addr: address,
+            DB:   db, // 0 means default DB
+        }),
+        Timeout: timeout,
+    }
 }
 
 func NewRedisStoreWithCreds(address string, db int, username string, password string) StoreManager {
-	return &RedisStore{
-		logger: log.NewLog(fmt.Sprintf("redis:%s", address)),
-		client: redis.NewClient(&redis.Options{
-			Addr:     address,
-			Username: username,
-			Password: password,
-			DB:       db,
-		}),
-		Timeout: DefaultTimeout,
-	}
+    return &RedisStore{
+        logger: slf4go.NewLog(fmt.Sprintf("redis:%s", address)),
+        client: redis.NewClient(&redis.Options{
+            Addr:     address,
+            Username: username,
+            Password: password,
+            DB:       db,
+        }),
+        Timeout: DefaultTimeout,
+    }
 }
 
 // SetLogLevel for RedisStore implements the Loggable interface
-func (csm *RedisStore) SetLogLevel(level log.LogLevel) {
-	csm.logger.Level = level
+func (csm *RedisStore) SetLogLevel(level slf4go.LogLevel) {
+    csm.logger.Level = level
 }
 
 func (csm *RedisStore) GetConfig(id string) (*api.Configuration, bool) {
-	ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
-	defer cancel()
+    ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
+    defer cancel()
 
-	cmd := csm.client.Get(ctx, id)
-	data, err := cmd.Bytes()
-	if err == redis.Nil {
-		csm.logger.Debug("key '%s' not found", id)
-	} else if err != nil {
-		csm.logger.Error(err.Error())
-	} else {
-		var cfg api.Configuration
+    cmd := csm.client.Get(ctx, id)
+    data, err := cmd.Bytes()
+    if err == redis.Nil {
+        csm.logger.Debug("key '%s' not found", id)
+    } else if err != nil {
+        csm.logger.Error(err.Error())
+    } else {
+        var cfg api.Configuration
 
-		if err = cfg.UnmarshalBinary(data); err != nil {
-			csm.logger.Error("cannot unmarshal data, %q", err)
-		} else {
-			return &cfg, true
-		}
-	}
-	return nil, false
+        if err = cfg.UnmarshalBinary(data); err != nil {
+            csm.logger.Error("cannot unmarshal data, %q", err)
+        } else {
+            return &cfg, true
+        }
+    }
+    return nil, false
 }
 
 func (csm *RedisStore) PutConfig(id string, cfg *api.Configuration) (err error) {
-	ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
-	defer cancel()
+    ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
+    defer cancel()
 
-	if id == "" {
-		csm.logger.Error("Cannot store a configuration with an empty ID")
-		return IllegalStoreError
-	}
+    if id == "" {
+        csm.logger.Error("Cannot store a configuration with an empty ID")
+        return IllegalStoreError
+    }
 
-	if cfg == nil {
-		csm.logger.Error("Attempting to store a nil configuration (%s)", id)
-		return IllegalStoreError
-	}
-	_, err = csm.client.Set(ctx, id, cfg, NeverExpire).Result()
-	return
+    if cfg == nil {
+        csm.logger.Error("Attempting to store a nil configuration (%s)", id)
+        return IllegalStoreError
+    }
+    _, err = csm.client.Set(ctx, id, cfg, NeverExpire).Result()
+    return
 }
 
 func (csm *RedisStore) GetStateMachine(id string) (cfg *api.FiniteStateMachine, ok bool) {
-	ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
-	defer cancel()
+    ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
+    defer cancel()
 
-	cmd := csm.client.Get(ctx, id)
-	data, err := cmd.Bytes()
-	if err == redis.Nil {
-		csm.logger.Debug("key '%s' not found", id)
-	} else if err != nil {
-		csm.logger.Error(err.Error())
-	} else {
-		var stateMachine api.FiniteStateMachine
+    cmd := csm.client.Get(ctx, id)
+    data, err := cmd.Bytes()
+    if err == redis.Nil {
+        csm.logger.Debug("key '%s' not found", id)
+    } else if err != nil {
+        csm.logger.Error(err.Error())
+    } else {
+        var stateMachine api.FiniteStateMachine
 
-		if err = stateMachine.UnmarshalBinary(data); err != nil {
-			csm.logger.Error("cannot unmarshal data, %q", err)
-		} else {
-			return &stateMachine, true
-		}
-	}
-	return nil, false
+        if err = stateMachine.UnmarshalBinary(data); err != nil {
+            csm.logger.Error("cannot unmarshal data, %q", err)
+        } else {
+            return &stateMachine, true
+        }
+    }
+    return nil, false
 }
 
 func (csm *RedisStore) PutStateMachine(id string, stateMachine *api.FiniteStateMachine) (err error) {
-	ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
-	defer cancel()
+    ctx, cancel := context.WithTimeout(DefaultContext, csm.Timeout)
+    defer cancel()
 
-	if id == "" {
-		csm.logger.Error("Cannot store a statemachine with an empty ID")
-		return IllegalStoreError
-	}
+    if id == "" {
+        csm.logger.Error("Cannot store a statemachine with an empty ID")
+        return IllegalStoreError
+    }
 
-	if stateMachine == nil {
-		csm.logger.Error("Attempting to store a nil statemachine (%s)", id)
-		return IllegalStoreError
-	}
-	_, err = csm.client.Set(ctx, id, stateMachine, NeverExpire).Result()
-	return
+    if stateMachine == nil {
+        csm.logger.Error("Attempting to store a nil statemachine (%s)", id)
+        return IllegalStoreError
+    }
+    _, err = csm.client.Set(ctx, id, stateMachine, NeverExpire).Result()
+    return
 }

--- a/storage/redis_store_test.go
+++ b/storage/redis_store_test.go
@@ -56,7 +56,7 @@ var _ = Describe("RedisStore", func() {
 
             localAddress := fmt.Sprintf("localhost:%s", redisPort)
 
-            store = storage.NewRedisStore(localAddress, storage.DefaultRedisDb)
+            store = storage.NewRedisStore(localAddress, storage.DefaultRedisDb, testTimeout, storage.DefaultMaxRetries)
             Expect(store).ToNot(BeNil())
             store.SetTimeout(testTimeout)
             // Mute unnecessary logging during tests; re-enable (


### PR DESCRIPTION
Added:

- a `-timeout` option to increase timeouts;
- a `-max-retries` option to add retrying (on re-triable errors);
- ensuring the context expiration is handled gracefully
- fixes an incorrect BAD REQUEST error being returned, instead of a NOT FOUND.