### PR TITLE
Make config immutable & add PUT endpoint for Statemachines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bin/
 
 # Protobuf Generated code
 *.pb.go
+certs/
+scratch.go

--- a/README.md
+++ b/README.md
@@ -220,13 +220,13 @@ Trying to create an FSM with an existing ID will cause a `409 Conflict` error to
 
 While it is recommended that changing the `state` or the `configuration` of an FSM is **not** done via API calls as a matter of course, there may be situations in which this may be unavoidable, especially when a new `Configuration` `version` needs to be released and existing FSMs need to use the new one (for example, because the business flow has changed, or a better way to model it has been identified).
 
-In order to allow for those scenarios, there is a `PUT` endpoint that allows for a `statemachine` to be modified: either a new `config_id` or `state` (or both) can be specified:
+In order to allow for those scenarios, there is a `PUT` endpoint that allows for a `statemachine` to be modified: either a new `configuration_version` or `current_state` (or both) can be specified:
 
 ```
 PUT /api/v1/statemachines/{config}/{id}
 
 {
-  "configuration_version": "test.orders:v4",
+  "configuration_version": "v4",
   "current_state": "accepted"
 }
 ```
@@ -248,7 +248,7 @@ HTTP/1.1 200 OK
 
 
 └─( http --json PUT :7399/api/v1/statemachines/test.orders/2 \
-        configuration_version=test.orders:v4 \
+        configuration_version=v4 \
         current_state=accepted
 
 HTTP/1.1 200 OK
@@ -278,7 +278,7 @@ If a non-existent configuration is used, a `404` error code is returned:
 
 ```
 └─( http --json PUT :7399/api/v1/statemachines/test.orders/2 \
-        configuration_version=test.orders:v5 \
+        configuration_version=v5 \
         current_state=accepted
 
 HTTP/1.1 404 Not Found
@@ -303,6 +303,16 @@ HTTP/1.1 200 OK
     }
 }
 ```
+
+> **Important**
+>
+> Given that the `configuration.name` defines the "type" of the FSM, this **cannot** be changed with a PUT request: the `cfg_name` is taken from the API URI path and is joined with the new request `configuration_version` to arrive at a full `Configuration` ID.
+>
+> This will **not** work:
+>
+> `PUT /api/v1/statemachines/orders/123456  configuration_version=devices:v1`
+>
+> even if a `devices:v1` configuration does exist: a 404 error would be returned as we would be looking up a configuration with an ID of `orders:devices:v1`.
 
 
 ### Event Outcomes

--- a/grpc/grpc_server.go
+++ b/grpc/grpc_server.go
@@ -147,7 +147,7 @@ func (s *grpcSubscriber) GetEventOutcome(ctx context.Context, request *protos.Ge
 	*protos.EventResponse, error) {
 
 	s.Logger.Debug("looking up EventOutcome %s", request.GetId())
-	dest := strings.Split(request.GetId(), "#")
+	dest := strings.Split(request.GetId(), storage.KeyPrefixIDSeparator)
 	if len(dest) != 2 {
 		return nil, status.Error(codes.InvalidArgument,
 			fmt.Sprintf("invalid destination [%s] expected: <type>#<id>", request.GetId()))

--- a/grpc/grpc_server_test.go
+++ b/grpc/grpc_server_test.go
@@ -158,12 +158,14 @@ var _ = Describe("GrpcServer", func() {
 			cfg      *api.Configuration
 			fsm      *api.FiniteStateMachine
 			done     func()
-			store    = storage.NewInMemoryStore()
+			store    storage.StoreManager
 		)
-		store.SetLogLevel(logging.NONE)
 
 		// Server setup
 		BeforeEach(func() {
+			store = storage.NewInMemoryStore()
+			store.SetLogLevel(logging.NONE)
+
 			listener, _ = net.Listen("tcp", ":0")
 			cc, _ := g.Dial(listener.Addr().String(), g.WithInsecure())
 			client = api.NewStatemachineServiceClient(cc)
@@ -186,7 +188,7 @@ var _ = Describe("GrpcServer", func() {
 		AfterEach(func() {
 			done()
 		})
-		// Store setup
+		// Test data setup
 		BeforeEach(func() {
 			cfg = &api.Configuration{
 				Name:    "test-conf",

--- a/pubsub/listener.go
+++ b/pubsub/listener.go
@@ -57,7 +57,7 @@ func (listener *EventsListener) ListenForMessages() {
 		// TODO: this is an API change and needs to be documented
 		// Destination comprises both the type (configuration name) and ID of the statemachine,
 		// separated by the # character: <type>#<id> (e.g., `order#1234`)
-		dest := strings.Split(request.Dest, "#")
+		dest := strings.Split(request.Dest, storage.KeyPrefixIDSeparator)
 		if len(dest) != 2 {
 			listener.PostNotificationAndReportOutcome(makeResponse(&request,
 				protos.EventOutcome_MissingDestination,
@@ -114,7 +114,7 @@ func (listener *EventsListener) ListenForMessages() {
 }
 
 func (listener *EventsListener) reportOutcome(response *protos.EventResponse) {
-	smType := strings.Split(response.Outcome.Dest, "#")[0]
+	smType := strings.Split(response.Outcome.Dest, storage.KeyPrefixIDSeparator)[0]
 	if err := listener.store.AddEventOutcome(response.EventId, smType, response.Outcome,
 		storage.NeverExpire); err != nil {
 		listener.logger.Error("could not add outcome to store: %v", err)

--- a/server/configuration_handlers.go
+++ b/server/configuration_handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/massenz/statemachine-proto/golang/api"
 	pj "google.golang.org/protobuf/encoding/protojson"
 	"net/http"
+	"strings"
 )
 
 func CreateConfigurationHandler(w http.ResponseWriter, r *http.Request) {
@@ -45,6 +46,12 @@ func CreateConfigurationHandler(w http.ResponseWriter, r *http.Request) {
 
 	err = storeManager.PutConfig(&config)
 	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			logger.Debug("attempts to POST an existing configuration id: %v", err)
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		}
+		logger.Error("cannot store Configuration to store: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/http_server.go
+++ b/server/http_server.go
@@ -75,6 +75,8 @@ func NewRouter() *mux.Router {
 		CreateStatemachineHandler).Methods("POST")
 	r.HandleFunc(strings.Join([]string{ApiPrefix, StatemachinesEndpoint, "{cfg_name}", "{sm_id}"}, "/"),
 		GetStatemachineHandler).Methods("GET")
+	r.HandleFunc(strings.Join([]string{ApiPrefix, StatemachinesEndpoint, "{cfg_name}", "{sm_id}"}, "/"),
+		ModifyStatemachineHandler).Methods("PUT")
 
 	r.HandleFunc(strings.Join([]string{ApiPrefix, EventsEndpoint, "{cfg_name}", "{evt_id}"}, "/"),
 		GetEventHandler).Methods("GET")

--- a/server/statemachine_handlers_test.go
+++ b/server/statemachine_handlers_test.go
@@ -29,13 +29,15 @@ import (
 	"github.com/massenz/statemachine-proto/golang/api"
 )
 
-func ReaderFromRequest(request *server.StateMachineRequest) io.Reader {
+// ReaderFromRequest takes a request object and creates a Reader to be used
+// as the body of the request.
+func ReaderFromRequest(request interface{}) io.Reader {
 	jsonBytes, err := json.Marshal(request)
 	Expect(err).ToNot(HaveOccurred())
 	return bytes.NewBuffer(jsonBytes)
 }
 
-var _ = Describe("Handlers", func() {
+var _ = Describe("Statemachine Handlers", func() {
 	var (
 		req    *http.Request
 		writer *httptest.ResponseRecorder
@@ -49,7 +51,7 @@ var _ = Describe("Handlers", func() {
 	// Disabling verbose logging, as it pollutes test output;
 	// set it back to DEBUG when tests fail, and you need to
 	// diagnose the failure.
-	server.SetLogLevel(log.WARN)
+	server.SetLogLevel(log.NONE)
 
 	Context("when creating state machines", func() {
 		BeforeEach(func() {
@@ -61,8 +63,8 @@ var _ = Describe("Handlers", func() {
 			var request *server.StateMachineRequest
 			BeforeEach(func() {
 				request = &server.StateMachineRequest{
-					ID:                   "test-machine",
-					ConfigurationVersion: "test-config:v1",
+					ID:            "test-machine",
+					Configuration: "test-config:v1",
 				}
 				config := &api.Configuration{
 					Name:          "test-config",
@@ -105,22 +107,18 @@ var _ = Describe("Handlers", func() {
 				Expect(fsm.State).To(Equal("start"))
 			})
 			It("should return a Conflict error if the ID already exists", func() {
-				store.SetLogLevel(log.DEBUG)
-				server.SetLogLevel(log.DEBUG)
 				Expect(store.PutStateMachine(request.ID, &api.FiniteStateMachine{
-					ConfigId: request.ConfigurationVersion,
+					ConfigId: request.Configuration,
 					State:    "start",
 				})).ToNot(HaveOccurred())
 				router.ServeHTTP(writer, req)
-				store.SetLogLevel(log.NONE)
-				server.SetLogLevel(log.NONE)
 				Expect(writer.Code).To(Equal(http.StatusConflict))
 			})
 		})
 		Context("without specifying an ID", func() {
 			BeforeEach(func() {
 				request := &server.StateMachineRequest{
-					ConfigurationVersion: "test-config:v1",
+					Configuration: "test-config:v1",
 				}
 				config := &api.Configuration{
 					Name:          "test-config",
@@ -151,12 +149,11 @@ var _ = Describe("Handlers", func() {
 			})
 
 		})
-
 		Context("with a non-existent configuration", func() {
 			BeforeEach(func() {
 				request := &server.StateMachineRequest{
-					ConfigurationVersion: "test-config:v2",
-					ID:                   "1234",
+					Configuration: "test-config:v2",
+					ID:            "1234",
 				}
 				req = httptest.NewRequest(http.MethodPost,
 					strings.Join([]string{server.ApiPrefix, server.StatemachinesEndpoint}, "/"),
@@ -171,6 +168,103 @@ var _ = Describe("Handlers", func() {
 				Expect(json.Unmarshal(writer.Body.Bytes(), &response)).To(HaveOccurred())
 				_, found := store.GetConfig("1234")
 				Expect(found).To(BeFalse())
+			})
+		})
+	})
+
+	Context("when modifying state machines", func() {
+		var configName string
+		var fsmId string
+
+		BeforeEach(func() {
+			writer = httptest.NewRecorder()
+			store = storage.NewInMemoryStore()
+			server.SetStore(store)
+		})
+		Context("with a valid request", func() {
+			var request *server.StateMachineChangeRequest
+			BeforeEach(func() {
+				configName = "test.config"
+				fsmId = "12345-abcdef"
+				request = &server.StateMachineChangeRequest{
+					ConfigurationVersion: "v2",
+					CurrentState:         "new-state",
+				}
+				config := &api.Configuration{
+					Name:          configName,
+					Version:       "v1",
+					States:        nil,
+					Transitions:   nil,
+					StartingState: "old-state",
+				}
+				Expect(store.PutConfig(config)).ToNot(HaveOccurred())
+				fsm := &api.FiniteStateMachine{
+					ConfigId: GetVersionId(config),
+					State:    config.StartingState,
+					History: []*api.Event{
+						{Transition: &api.Transition{Event: "order_placed"}, Originator: ""},
+						{Transition: &api.Transition{Event: "checked_out"}, Originator: ""},
+					},
+				}
+				Expect(store.PutStateMachine(fsmId, fsm)).ToNot(HaveOccurred())
+				config.Version = request.ConfigurationVersion
+				Expect(store.PutConfig(config)).ToNot(HaveOccurred())
+				req = httptest.NewRequest(http.MethodPut,
+					strings.Join([]string{
+						server.ApiPrefix, server.StatemachinesEndpoint, configName, fsmId,
+					}, "/"),
+					ReaderFromRequest(request))
+			})
+			It("should succeed", func() {
+				router.ServeHTTP(writer, req)
+				Expect(writer.Code).To(Equal(http.StatusOK))
+				response := server.StateMachineResponse{}
+				Expect(json.Unmarshal(writer.Body.Bytes(), &response)).ToNot(HaveOccurred())
+
+				Expect(response.ID).To(Equal(fsmId))
+				Expect(response.StateMachine.ConfigId).To(Equal(configName + ":" + request.ConfigurationVersion))
+				Expect(response.StateMachine.State).To(Equal(request.CurrentState))
+			})
+			It("should save it in the backing store", func() {
+				router.ServeHTTP(writer, req)
+				Expect(writer.Code).To(Equal(http.StatusOK))
+				fsm, found := store.GetStateMachine(fsmId, configName)
+				Expect(found).To(BeTrue())
+				Expect(fsm.State).To(Equal(request.CurrentState))
+				Expect(fsm.ConfigId).To(Equal(configName + ":" + request.ConfigurationVersion))
+				Expect(len(fsm.History)).To(Equal(2))
+			})
+			It("should return a NotFound if the FSM does not exist", func() {
+				req = httptest.NewRequest(http.MethodPut,
+					strings.Join([]string{
+						server.ApiPrefix, server.StatemachinesEndpoint, configName, "fake-fsm",
+					}, "/"),
+					ReaderFromRequest(request))
+				router.ServeHTTP(writer, req)
+				Expect(writer.Code).To(Equal(http.StatusNotFound))
+
+			})
+			It("should return a NotFound error if the Config does not exist", func() {
+				request = &server.StateMachineChangeRequest{
+					ConfigurationVersion: "v8",
+					CurrentState:         "fake-state",
+				}
+				req = httptest.NewRequest(http.MethodPut,
+					strings.Join([]string{
+						server.ApiPrefix, server.StatemachinesEndpoint, configName, fsmId,
+					}, "/"),
+					ReaderFromRequest(request))
+				router.ServeHTTP(writer, req)
+				Expect(writer.Code).To(Equal(http.StatusNotFound))
+			})
+			It("should fail gracefully with a malformed request", func() {
+				req = httptest.NewRequest(http.MethodPut,
+					strings.Join([]string{
+						server.ApiPrefix, server.StatemachinesEndpoint, configName, fsmId,
+					}, "/"),
+					bytes.NewReader([]byte(`{"not": "my", "best": json}`)))
+				router.ServeHTTP(writer, req)
+				Expect(writer.Code).To(Equal(http.StatusBadRequest))
 			})
 		})
 	})

--- a/server/types.go
+++ b/server/types.go
@@ -32,9 +32,12 @@ type MessageResponse struct {
 // and a reference to a fully qualified Configuration version.
 //
 // If the ID is not specified, a new UUID will be generated and returned.
+// The ConfigurationVersion is required and the CurrentState is only used when
+// requesting a change to an existing FSM (PUT), and will otherwise be ignored.
 type StateMachineRequest struct {
-	ID                   string `json:"id"`
+	ID                   string `json:"id,omitempty"`
 	ConfigurationVersion string `json:"configuration_version"`
+	CurrentState         string `json:"current_state,omitempty"`
 }
 
 // StateMachineResponse is returned when a new FSM is created, or as a response to a GET request

--- a/server/types.go
+++ b/server/types.go
@@ -32,11 +32,20 @@ type MessageResponse struct {
 // and a reference to a fully qualified Configuration version.
 //
 // If the ID is not specified, a new UUID will be generated and returned.
-// The ConfigurationVersion is required and the CurrentState is only used when
-// requesting a change to an existing FSM (PUT), and will otherwise be ignored.
+// The Configuration is required and **must** match an existing Configuration full `name` and
+// `version` (e.g., `orders:v2`)
 type StateMachineRequest struct {
-	ID                   string `json:"id,omitempty"`
-	ConfigurationVersion string `json:"configuration_version"`
+	ID            string `json:"id,omitempty"`
+	Configuration string `json:"configuration_version"`
+}
+
+// StateMachineChangeRequest represents a request to modify (PUT)( an existing FSM.
+//
+// The ConfigurationVersion represents **only** the new `version` of the Configuration to be
+// used (the `name` is passed in the API URI path).
+// Both ConfigurationVersion and CurrentState are optional.
+type StateMachineChangeRequest struct {
+	ConfigurationVersion string `json:"configuration_version,omitempty"`
 	CurrentState         string `json:"current_state,omitempty"`
 }
 

--- a/storage/memory_store.go
+++ b/storage/memory_store.go
@@ -106,13 +106,14 @@ func (csm *InMemoryStore) PutConfig(cfg *protos.Configuration) error {
 }
 
 func (csm *InMemoryStore) GetStateMachine(id string, cfg string) (*protos.FiniteStateMachine, bool) {
-	csm.logger.Debug("Fetching StateMachine [%s#%s]", cfg, id)
 	key := NewKeyForMachine(id, cfg)
-	machine := protos.FiniteStateMachine{}
+	csm.logger.Debug("Getting StateMachine [%s]", key)
+	var machine protos.FiniteStateMachine
 	if csm.get(key, &machine) {
-		csm.logger.Debug("Found StateMachine [%s#%s]: %s", cfg, id, machine.State)
+		csm.logger.Debug("Found StateMachine [%s] in state: %s", key, machine.State)
 		return &machine, true
 	}
+	csm.logger.Debug("Not found for key %s", key)
 	return nil, false
 }
 

--- a/storage/redis_store.go
+++ b/storage/redis_store.go
@@ -104,9 +104,6 @@ func (csm *RedisStore) PutStateMachine(id string, stateMachine *protos.FiniteSta
 	}
 	configName := strings.Split(stateMachine.ConfigId, api.ConfigurationVersionSeparator)[0]
 	key := NewKeyForMachine(id, configName)
-	if csm.client.Exists(context.Background(), key).Val() == 1 {
-		return AlreadyExistsError(key)
-	}
 	return csm.put(key, stateMachine, NeverExpire)
 }
 

--- a/storage/redis_store.go
+++ b/storage/redis_store.go
@@ -42,7 +42,7 @@ type RedisStore struct {
 
 func (csm *RedisStore) GetAllInState(cfg string, state string) []*protos.FiniteStateMachine {
 	// TODO [#33] Ability to query for all machines in a given state
-	csm.logger.Error("Not implemented")
+	csm.logger.Error(NotImplementedError("GetAllInState").Error())
 	return nil
 }
 
@@ -81,15 +81,18 @@ func (csm *RedisStore) GetStateMachine(id string, cfg string) (*protos.FiniteSta
 
 func (csm *RedisStore) PutConfig(cfg *protos.Configuration) error {
 	if cfg == nil {
-		return IllegalStoreError
+		return IllegalStoreError("nil config")
 	}
 	key := NewKeyForConfig(api.GetVersionId(cfg))
+	if csm.client.Exists(context.Background(), key).Val() == 1 {
+		return AlreadyExistsError(key)
+	}
 	return csm.put(key, cfg, NeverExpire)
 }
 
 func (csm *RedisStore) PutEvent(event *protos.Event, cfg string, ttl time.Duration) error {
 	if event == nil {
-		return IllegalStoreError
+		return IllegalStoreError("nil event")
 	}
 	key := NewKeyForEvent(event.EventId, cfg)
 	return csm.put(key, event, ttl)
@@ -97,16 +100,19 @@ func (csm *RedisStore) PutEvent(event *protos.Event, cfg string, ttl time.Durati
 
 func (csm *RedisStore) PutStateMachine(id string, stateMachine *protos.FiniteStateMachine) error {
 	if stateMachine == nil {
-		return IllegalStoreError
+		return IllegalStoreError("nil statemachine")
 	}
 	configName := strings.Split(stateMachine.ConfigId, api.ConfigurationVersionSeparator)[0]
 	key := NewKeyForMachine(id, configName)
+	if csm.client.Exists(context.Background(), key).Val() == 1 {
+		return AlreadyExistsError(key)
+	}
 	return csm.put(key, stateMachine, NeverExpire)
 }
 
 func (csm *RedisStore) AddEventOutcome(id string, cfg string, response *protos.EventOutcome, ttl time.Duration) error {
 	if response == nil {
-		return IllegalStoreError
+		return IllegalStoreError("nil response")
 	}
 	key := NewKeyForOutcome(id, cfg)
 	return csm.put(key, response, ttl)

--- a/storage/redis_store_test.go
+++ b/storage/redis_store_test.go
@@ -91,6 +91,10 @@ var _ = Describe("RedisStore", func() {
 			Expect(proto.Unmarshal(val, &found)).ToNot(HaveOccurred())
 			Expect(&found).To(Respect(cfg))
 		})
+		It("will not save a duplicate configurations", func() {
+			Expect(store.PutConfig(cfg)).ToNot(HaveOccurred())
+			Expect(store.PutConfig(cfg)).To(HaveOccurred())
+		})
 		It("should not fail for a non-existent FSM", func() {
 			data, ok := store.GetStateMachine("fake", "bad-config")
 			Expect(ok).To(BeFalse())

--- a/storage/types.go
+++ b/storage/types.go
@@ -16,11 +16,17 @@ import (
 	"time"
 )
 
+func Error(msg string) func(string) error {
+	return func(key string) error {
+		return fmt.Errorf(msg, key)
+	}
+}
+
 var (
-	IllegalStoreError   = fmt.Errorf("error storing invalid data")
-	ConfigNotFoundError = fmt.Errorf("configuration not found")
-	FSMNotFoundError    = fmt.Errorf("statemachine not found")
-	NotImplementedError = fmt.Errorf("this functionality has not been implemented yet")
+	IllegalStoreError   = Error("error storing invalid data: %v")
+	AlreadyExistsError  = Error("key %s already exists")
+	NotFoundError       = Error("key %s not found")
+	NotImplementedError = Error("functionality %s has not been implemented yet")
 )
 
 type ConfigurationStorageManager interface {


### PR DESCRIPTION
This PR finally addresses #21 and makes `Configurations` immutable: `POST`ing a request for a config ID that already exists will cause a CONFLICT error to be returned.

In order to address the use case of configuration changes (which will then require a new version to be POSTed) that ought to be tracked by FSMs, we have added a `PUT` endpoint to enable updating the version (and, optionally, the current state) of an existing FSM:

```
PUT /api/v1/statemachines/orders/123456  

{
  "configuration_version": "v3",
  "current_state": "shipped"
}
```

See the README for more details and examples.