### PR TITLE
Enable transition locking for FSM state change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,9 +99,8 @@ start: ## Starts the Redis and LocalStack containers, and Creates the SQS Queues
 	@for queue in events notifications; do \
 		aws --no-cli-pager --endpoint-url=http://localhost:4566 \
 			--region us-west-2 \
- 			sqs create-queue --queue-name $$queue; done >/dev/null
- 	# We need to wait for the SQS Queues to be up before starting the server.
-	#@RELEASE=$(release) BASEDIR=$(shell pwd) docker compose -f $(compose) --project-name sm up server -d
+ 			sqs create-queue --queue-name $$queue; done
+	@RELEASE=$(release) BASEDIR=$(shell pwd) docker compose -f $(compose) --project-name sm up server
 
 .PHONY: stop
 stop: ## Stops the Redis and LocalStack containers

--- a/grpc/grpc_server_test.go
+++ b/grpc/grpc_server_test.go
@@ -76,6 +76,10 @@ func (m *Mockstore) UpdateState(cfgName string, id string, oldState string, newS
 	return NotImplemented
 }
 
+func (csm *Mockstore) TxProcessEvent(id, cfgName string, evt *protos.Event) error {
+	return NotImplemented
+}
+
 func (m *Mockstore) GetEvent(id string, cfg string) (*protos.Event, storage.StoreErr) {
 	return nil, NotImplemented
 }

--- a/pubsub/listener.go
+++ b/pubsub/listener.go
@@ -11,7 +11,6 @@ package pubsub
 
 import (
 	"fmt"
-	. "github.com/massenz/go-statemachine/api"
 	"github.com/massenz/go-statemachine/storage"
 	log "github.com/massenz/slf4go/logging"
 	protos "github.com/massenz/statemachine-proto/golang/api"
@@ -55,65 +54,31 @@ func (listener *EventsListener) ListenForMessages() {
 				fmt.Sprintf("no statemachine ID specified")))
 			continue
 		}
-		config := request.GetConfig()
-		if config == "" {
+		cfgName := request.GetConfig()
+		if cfgName == "" {
 			listener.PostNotificationAndReportOutcome(makeResponse(&request,
 				protos.EventOutcome_MissingDestination,
 				fmt.Sprintf("no Configuration name specified")))
 			continue
 		}
 		// The event is well-formed, we can store for later retrieval
-		if err := listener.store.PutEvent(request.Event, config, storage.NeverExpire); err != nil {
+		if err := listener.store.PutEvent(request.Event, cfgName, storage.NeverExpire); err != nil {
 			listener.PostNotificationAndReportOutcome(makeResponse(&request,
 				protos.EventOutcome_InternalError,
 				fmt.Sprintf("could not store event: %v", err)))
 			continue
 		}
-		fsm, err := listener.store.GetStateMachine(fsmId, config)
-		if err != nil {
-			listener.PostNotificationAndReportOutcome(makeResponse(&request,
-				protos.EventOutcome_FsmNotFound,
-				fmt.Sprintf("statemachine [%s] could not be found", fsmId)))
-			continue
-		}
-		// TODO: cache the configuration locally: they are immutable anyway.
-		cfg, err := listener.store.GetConfig(fsm.ConfigId)
-		if err != nil {
-			listener.PostNotificationAndReportOutcome(makeResponse(&request,
-				protos.EventOutcome_ConfigurationNotFound,
-				fmt.Sprintf("configuration [%s] could not be found", fsm.ConfigId)))
-			continue
-		}
-		previousState := fsm.State
-		cfgFsm := ConfiguredStateMachine{
-			Config: cfg,
-			FSM:    fsm,
-		}
-		listener.logger.Debug("preparing to send event `%s` for FSM [%s] (current state: %s)",
-			request.Event.Transition.Event, fsmId, previousState)
-		if err := cfgFsm.SendEvent(request.Event); err != nil {
-			listener.PostNotificationAndReportOutcome(makeResponse(&request,
-				protos.EventOutcome_TransitionNotAllowed,
-				fmt.Sprintf("event [%s] could not be processed: %v",
-					request.GetEvent().GetTransition().GetEvent(), err)))
-			continue
-		}
-		if err := listener.store.PutStateMachine(fsmId, fsm); err != nil {
+		listener.logger.Debug("preparing to send event `%s` for FSM [%s]",
+			request.Event.Transition.Event, fsmId)
+		if err := listener.store.TxProcessEvent(fsmId, cfgName, request.Event); err != nil {
 			listener.PostNotificationAndReportOutcome(makeResponse(&request,
 				protos.EventOutcome_InternalError,
 				fmt.Sprintf("could not update statemachine [%s#%s] in store: %v",
-					config, fsmId, err)))
+					cfgName, fsmId, err)))
 			continue
 		}
-		if err := listener.store.UpdateState(config, fsmId, previousState, fsm.State); err != nil {
-			listener.PostNotificationAndReportOutcome(makeResponse(&request,
-				protos.EventOutcome_InternalError,
-				fmt.Sprintf("could not update statemachine state set (%s#%s): %v",
-					config, fsmId, err)))
-			continue
-		}
-		listener.logger.Debug("Event `%s` transitioned FSM [%s] to state `%s` from state `%s` - updating store",
-			request.Event.Transition.Event, fsmId, fsm.State, previousState)
+		listener.logger.Debug("Event `%s` successfully changed FSM [%s] state",
+			request.Event.Transition.Event, fsmId)
 		listener.reportOutcome(makeResponse(&request, protos.EventOutcome_Ok, ""))
 	}
 }

--- a/pubsub/listener_test.go
+++ b/pubsub/listener_test.go
@@ -34,7 +34,7 @@ var _ = Describe("A Listener", func() {
 			eventsCh = make(chan protos.EventRequest)
 			notificationsCh = make(chan protos.EventResponse)
 			store = storage.NewRedisStoreWithDefaults(redisContainer.Address)
-			store.SetLogLevel(logging.NONE)
+			store.SetLogLevel(logging.TRACE)
 			testListener = pubsub.NewEventsListener(&pubsub.ListenerOptions{
 				EventsChannel:        eventsCh,
 				NotificationsChannel: notificationsCh,
@@ -42,7 +42,7 @@ var _ = Describe("A Listener", func() {
 				ListenersPoolSize:    0,
 			})
 			// Set to DEBUG when diagnosing test failures
-			testListener.SetLogLevel(logging.NONE)
+			testListener.SetLogLevel(logging.DEBUG)
 		})
 		const eventId = "1234-abcdef"
 		It("can post error notifications", func() {
@@ -118,7 +118,7 @@ var _ = Describe("A Listener", func() {
 				g.Ω(len(fsm.History)).To(Equal(1))
 				g.Ω(fsm.History[0].Details).To(Equal("more details"))
 				g.Ω(fsm.History[0].Transition.Event).To(Equal("move"))
-			}).Should(Succeed())
+			}, 120*time.Millisecond, 40*time.Millisecond).Should(Succeed())
 			Eventually(func() storage.StoreErr {
 				_, err := store.GetEvent(event.EventId, "test")
 				return err

--- a/pubsub/listener_test.go
+++ b/pubsub/listener_test.go
@@ -10,6 +10,7 @@
 package pubsub_test
 
 import (
+	"fmt"
 	. "github.com/JiaYongfei/respect/gomega"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,7 +35,7 @@ var _ = Describe("A Listener", func() {
 			eventsCh = make(chan protos.EventRequest)
 			notificationsCh = make(chan protos.EventResponse)
 			store = storage.NewRedisStoreWithDefaults(redisContainer.Address)
-			store.SetLogLevel(logging.TRACE)
+			store.SetLogLevel(logging.NONE)
 			testListener = pubsub.NewEventsListener(&pubsub.ListenerOptions{
 				EventsChannel:        eventsCh,
 				NotificationsChannel: notificationsCh,
@@ -42,7 +43,7 @@ var _ = Describe("A Listener", func() {
 				ListenersPoolSize:    0,
 			})
 			// Set to DEBUG when diagnosing test failures
-			testListener.SetLogLevel(logging.DEBUG)
+			testListener.SetLogLevel(logging.NONE)
 		})
 		const eventId = "1234-abcdef"
 		It("can post error notifications", func() {
@@ -129,9 +130,8 @@ var _ = Describe("A Listener", func() {
 				EventId:    eventId,
 				Originator: "me",
 				Transition: &protos.Transition{
-					Event: "move",
+					Event: "fake",
 				},
-				Details: "more details",
 			}
 			request := protos.EventRequest{
 				Event:  &event,
@@ -143,14 +143,15 @@ var _ = Describe("A Listener", func() {
 			}()
 			eventsCh <- request
 			close(eventsCh)
-			Eventually(func(g Gomega) {
-				select {
-				case n := <-notificationsCh:
-					g.Ω(n.EventId).To(Equal(request.Event.EventId))
-					g.Ω(n.Outcome.Id).To(Equal(request.GetId()))
-					g.Ω(n.Outcome.Code).To(Equal(protos.EventOutcome_FsmNotFound))
-				}
-			}).Should(Succeed())
+			select {
+			case n := <-notificationsCh:
+				Ω(n.EventId).To(Equal(request.Event.EventId))
+				Ω(n.Outcome.Id).To(Equal(request.GetId()))
+				Ω(n.Outcome.Code).To(Equal(protos.EventOutcome_FsmNotFound))
+			case <-time.After(timeout):
+				Fail("timed out waiting for notification")
+			}
+			fmt.Println("3")
 		})
 		It("sends notifications for missing destinations", func() {
 			request := protos.EventRequest{
@@ -161,14 +162,14 @@ var _ = Describe("A Listener", func() {
 			go func() { testListener.ListenForMessages() }()
 			eventsCh <- request
 			close(eventsCh)
-			Eventually(func(g Gomega) {
-				select {
-				case n := <-notificationsCh:
-					Ω(n.EventId).To(Equal(request.Event.EventId))
-					Ω(n.Outcome).ToNot(BeNil())
-					Ω(n.Outcome.Code).To(Equal(protos.EventOutcome_MissingDestination))
-				}
-			}).Should(Succeed())
+			select {
+			case n := <-notificationsCh:
+				Ω(n.EventId).To(Equal(request.Event.EventId))
+				Ω(n.Outcome).ToNot(BeNil())
+				Ω(n.Outcome.Code).To(Equal(protos.EventOutcome_MissingDestination))
+			case <-time.After(timeout):
+				Fail("timed out waiting for notification")
+			}
 		})
 		It("should exit when the channel is closed", func() {
 			done := make(chan interface{})
@@ -207,7 +208,6 @@ var _ = Describe("A Listener", func() {
 			go func() { testListener.ListenForMessages() }()
 			eventsCh <- request
 			close(eventsCh)
-
 			Consistently(func() *protos.EventResponse {
 				select {
 				case n := <-notificationsCh:

--- a/storage/redis_store.go
+++ b/storage/redis_store.go
@@ -36,7 +36,7 @@ const (
 
 type RedisStore struct {
 	logger     *slf4go.Log
-	client     redis.Cmdable
+	client     redis.UniversalClient
 	Timeout    time.Duration
 	MaxRetries int
 }
@@ -276,6 +276,57 @@ func (csm *RedisStore) UpdateState(cfgName string, id string, oldState string, n
 	return nil
 }
 
+func (csm *RedisStore) TxProcessEvent(id, cfgName string, evt *protos.Event) error {
+	ctx, _ := context.WithTimeout(context.Background(), DefaultTimeout)
+	// See Tx example at https://redis.uptrace.dev/guide/go-redis-pipelines.html#transactions
+	txf := func(tx *redis.Tx) error {
+		csm.logger.Trace("Tx starts")
+		fsm, err := csm.GetStateMachine(id, cfgName)
+		if err != nil {
+			return err
+		}
+		csm.logger.Trace("Tx got SM [%s]", id)
+		cfg, err := csm.GetConfig(fsm.ConfigId)
+		if err != nil {
+			return err
+		}
+		csm.logger.Trace("Tx got CFG [%s]", api.GetVersionId(cfg))
+		if err = (&api.ConfiguredStateMachine{Config: cfg, FSM: fsm}).SendEvent(evt); err != nil {
+			return err
+		}
+		csm.logger.Trace("Tx changed SM to: %s", fsm.State)
+		// If the watched keys are unchanged, the Tx is committed
+		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			csm.logger.Trace("Tx committing change")
+			data, err := proto.Marshal(fsm)
+			if err != nil {
+				csm.logger.Error("cannot convert proto to bytes: %q", err)
+				return InvalidDataError(err.Error())
+			}
+			cmd := pipe.Set(ctx, NewKeyForMachine(id, cfgName), data, NeverExpire)
+			if cmd.Err() == nil {
+				csm.logger.Trace("Tx committed successfully")
+			}
+			return cmd.Err()
+		})
+		return err
+	}
+	for i := 0; i < DefaultMaxRetries; i++ {
+		key := NewKeyForMachine(id, cfgName)
+		csm.logger.Trace("(%d) watching %s", i, key)
+		err := csm.client.Watch(ctx, txf, key)
+		if err == redis.TxFailedErr {
+			// We may be able to retry
+			csm.logger.Trace("(%d) Tx failed, retrying", i)
+			continue
+		}
+		// err may be nil here, in which case, success!
+		csm.logger.Trace("returning with (%v)", err)
+		return err
+	}
+	return TooManyAttempts("")
+}
+
 /////// EventStore implementation
 
 func (csm *RedisStore) GetEvent(id string, cfg string) (*protos.Event, StoreErr) {
@@ -335,7 +386,7 @@ func NewRedisStore(address string, isCluster bool, db int, timeout time.Duration
 	logger := slf4go.NewLog(fmt.Sprintf("redis://%s/%d", address, db))
 
 	var tlsConfig *tls.Config
-	var client redis.Cmdable
+	var client redis.UniversalClient
 
 	if os.Getenv("REDIS_TLS") != "" {
 		logger.Info("Using TLS for Redis connection")

--- a/storage/types.go
+++ b/storage/types.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	log "github.com/massenz/slf4go/logging"
 	protos "github.com/massenz/statemachine-proto/golang/api"
+	"regexp"
 	"time"
 )
 
@@ -32,6 +33,20 @@ var (
 	NotImplementedError = Error("functionality %s has not been implemented yet")
 	TooManyAttempts     = Error("retries exceeded")
 )
+
+func IsNotFoundErr(err StoreErr) bool {
+	// Define the regular expression pattern
+	pattern := `^key\s+(\S+)\s+not\sfound$`
+
+	// Compile the regular expression pattern
+	re := regexp.MustCompile(pattern)
+
+	// Use the FindStringSubmatch function to get the matched groups
+	matches := re.FindStringSubmatch(err.Error())
+
+	// The first element of the matches slice is the whole matched string, so we skip it
+	return len(matches) > 1
+}
 
 type ConfigStore interface {
 	GetConfig(versionId string) (*protos.Configuration, StoreErr)

--- a/storage/types.go
+++ b/storage/types.go
@@ -72,6 +72,10 @@ type FSMStore interface {
 	//
 	// `oldState` may be empty in the case of a new FSM being created.
 	UpdateState(cfgName string, id string, oldState string, newState string) StoreErr
+
+	// TxProcessEvent processes an Event for the FSM in a transaction, guaranteeing that
+	// there will be no races when updating the FSM state.
+	TxProcessEvent(id, cfgName string, evt *protos.Event) StoreErr
 }
 
 type EventStore interface {

--- a/storage/types_test.go
+++ b/storage/types_test.go
@@ -1,0 +1,19 @@
+package storage_test
+
+import (
+	"github.com/massenz/go-statemachine/storage"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Types", func() {
+
+	It("should correctly match a regex", func() {
+		res := storage.IsNotFoundErr(storage.NotFoundError("fsm:test#fake-fsm"))
+		Expect(res).To(BeTrue())
+	})
+	It("should not match the wrong regex", func() {
+		res := storage.IsNotFoundErr(storage.AlreadyExistsError("fsm:test#fake-fsm"))
+		Expect(res).ToNot(BeTrue())
+	})
+})


### PR DESCRIPTION
FSM events cause state transitions which may cause race conditions if events arrive in rapid successions, with unpredictable results.

This PR enables the use of Redis Transactions (using WATCH) with optimistic locking, to prevent modifying a FSM while it is being modified by another concurrent process.
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- New Feature: Enable transition locking for FSM state change using Redis Transactions with optimistic locking to prevent race conditions during state transitions.
- Test: Added test cases to check if a regex matches correctly.

> "With Redis Transactions,  
> Race conditions are no longer our afflictions.  
> Our code is now more robust,  
> And our users can trust,  
> That their data is safe from any disruptions."
<!-- end of auto-generated comment: release notes by openai -->