### PR TITLE
Updated CLI to use latest version of packages

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -11,7 +11,7 @@ services:
     container_name: "redis"
     image: "redis:6.2-alpine"
     hostname: redis
-    command: "redis-cmd --save 60 1 --loglevel warning"
+    command: "redis-server --save 60 1 --loglevel warning"
     volumes:
       - "${TMPDIR:-/tmp}/redis:/data"
     ports:

--- a/fsm-cli/client/client.go
+++ b/fsm-cli/client/client.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/massenz/go-statemachine/api"
-	"github.com/massenz/go-statemachine/grpc"
+	"github.com/massenz/go-statemachine/pkg/api"
+	"github.com/massenz/go-statemachine/pkg/grpc"
 	protos "github.com/massenz/statemachine-proto/golang/api"
 )
 

--- a/fsm-cli/go.mod
+++ b/fsm-cli/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/golang/protobuf v1.5.3
-	github.com/massenz/go-statemachine v0.12.0-gdd3da8f
+	github.com/massenz/go-statemachine v0.13.0-g6e9e42d
 	github.com/massenz/statemachine-proto/golang v1.2.0-g8dbe9c5
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.31.1

--- a/fsm-cli/go.sum
+++ b/fsm-cli/go.sum
@@ -331,8 +331,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/massenz/go-statemachine v0.12.0-gdd3da8f h1:gw/fPSwJf58wJTUK2lOx1SkNX3Wc1lNpQAT95oeMcfI=
-github.com/massenz/go-statemachine v0.12.0-gdd3da8f/go.mod h1:FUv7P46WsvRQYveiC+xcSd8M/Z/cVDqY5Iwc3PzI28A=
+github.com/massenz/go-statemachine v0.13.0-g6e9e42d h1:yQtpcM06oZK2l7Twj8rhAi7CgbJmgNmtZlZy3ZMv7Do=
+github.com/massenz/go-statemachine v0.13.0-g6e9e42d/go.mod h1:ckSORHgojC621m/W8kSdHK9NooOV86rYwo6S+6uwRZI=
 github.com/massenz/slf4go v0.3.2-g4eb5504 h1:tRrxPOKcqNKQn25eS8Dy9bW3NMNPpuK4Sla9jKfWmSs=
 github.com/massenz/slf4go v0.3.2-g4eb5504/go.mod h1:ZJjthXAnZMJGwXUz3Z3v5uyban00uAFFoDYODOoLFpw=
 github.com/massenz/statemachine-proto/golang v1.2.0-g8dbe9c5 h1:0QLU3fwkZg2s17QsjrJ4RKdxmWbsvF7WPzBeEO1m32Y=


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

### Release Notes:
- **Refactor:** Updated import paths in `client.go` for `api` and `grpc` packages to use the latest version.

> "Code paths realigned, packages updated,
> CLI now shines bright, bugs abated.
> With imports in sync, errors fade away,
> Users rejoice, as progress finds its way."
<!-- end of auto-generated comment: release notes by openai -->